### PR TITLE
Pool Allocator Implementation

### DIFF
--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -1,5 +1,6 @@
 mod buddy_allocator;
 mod frame_allocator;
+mod pool_allocator;
 
 use crate::{
     constants::{KB, MB},

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -113,10 +113,6 @@ unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
 
         let start_bit = (ptr.as_ptr() as usize - start_addr) / N;
 
-        // Check if the bit is already flipped
-        let byte_index = start_bit / 8;
-        let bit_pos = start_bit % 8;
-
         // Sanity check: We should have layout.size() / N blocks starting from start_bit
         for i in 0..layout.size() / N {
             let byte_index = (start_bit + i) / 8;

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -17,9 +17,8 @@ impl<const N: usize> PoolAllocator<N>{
     pub fn new(region: NonNull<[u8]>) -> Self {
         // Calculate the required bitmap size in bytes, because each stores an u8
 
-        // We will round down to ensure that it doesn't crash
-        // It will always use lesser than or equal to the region size
-        let bitmap_size = (region.len() / N) / 8;
+        // Round up the division to the nearest whole number
+        let bitmap_size = (region.len() / N).div_ceil(8);
 
         // Initialize the bitmap vector with zeros
         let bitmap = UnsafeCell::new(vec![0u8; bitmap_size].into_boxed_slice());

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -1,0 +1,49 @@
+use core::{
+    alloc::{Layout, Allocator},
+    ptr::NonNull,
+};
+use crate::constants::KB;
+
+#[derive(Clone, Copy)]
+pub struct PoolAllocator<const N: usize> {
+    region: NonNull<[u8]>,
+}
+
+impl<const N: usize> PoolAllocator<N>{
+    /// Creates a new Pool Allocator that allocates a huge chunk of memory
+    pub fn new(region: NonNull<[u8]>) -> Self {
+        // Here, region is a Layout Pointer?
+        // So we can use region to obtain the giant chunk of memory?
+        todo!();
+    }
+
+}
+
+unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
+        // Tries to use the layout and self.region to find a potential next slot to allocate this region,
+        // and return the pointer to it.
+        todo!()
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // Marks some pointer region as unused, might need more thinking before writing it up,
+        // otherwise might need to also allow each pointer location to store a "used/unused" information
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+
+    use std::error::Error;
+
+    // Importing pool allocator for testing
+    use crate::mem::pool_allocator::PoolAllocator;
+
+    #[test]
+    fn pool_allocator_simple() -> Result<(), Box<dyn Error>> {
+        todo!();
+    }
+}

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -8,7 +8,6 @@ use core::{
 
 pub struct PoolAllocator<const N: usize> {
     region: NonNull<[u8]>,
-    // bitmap: UnsafeCell<Box<[u8]>>,
 }
 
 impl<const N: usize> PoolAllocator<N> {

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -1,15 +1,15 @@
 use core::{
     alloc::{Layout, Allocator, AllocError},
     ptr::NonNull,
-    cell::UnsafeCell,
+    mem::size_of,
+    slice,
+    ptr,
 };
 
-use alloc::boxed::Box;
-use alloc::vec;
 
 pub struct PoolAllocator<const N: usize> {
     region: NonNull<[u8]>,
-    bitmap: UnsafeCell<Box<[u8]>>,
+    // bitmap: UnsafeCell<Box<[u8]>>,
 }
 
 impl<const N: usize> PoolAllocator<N>{
@@ -23,12 +23,44 @@ impl<const N: usize> PoolAllocator<N>{
         // Calculate the required bitmap size in bytes, because each stores an u8
 
         // Round up the division to the nearest whole number
+        // This unit is in bytes
         let bitmap_size = (region.len() / N).div_ceil(8);
 
-        // Initialize the bitmap vector with zeros
-        let bitmap = UnsafeCell::new(vec![0u8; bitmap_size].into_boxed_slice());
+        // To allow the first block to always store the size of bitmap
+        assert!(N >= size_of::<usize>());
 
-        Self { region, bitmap }
+        // Calculate how many blocks the bitmap occupies
+        let bitmap_blocks = bitmap_size.div_ceil(N);
+        let total_blocks = region.len().div_ceil(N);
+
+        // Ensure the region is large enough for the size of bitmap + bitmap_blocks
+        // + at least 1 extra block is available
+        assert!(total_blocks >= bitmap_blocks + 1 + 1);
+
+        unsafe {
+            let region_ptr = region.as_ptr();
+
+            // The first block is used to store how large the bitmap is
+            ptr::write(region_ptr as *mut usize, bitmap_size);
+
+            // Initialize the bitmap area to zero, which is 1 block away from the start
+            ptr::write_bytes((region_ptr as *mut u8).add(N), 0, bitmap_size);
+
+            // Get a mutable slice of the region where the bitmap is stored
+            let bitmap_slice = slice::from_raw_parts_mut((region_ptr as *mut u8).add(N), bitmap_size);
+
+            // Mark the blocks used by the bitmap as used in the bitmap
+            for i in 0..bitmap_blocks {
+                let byte_index = i / 8;
+                let bit_index = i % 8;
+                if byte_index < bitmap_size {
+                    // Set the bit to mark the block as used
+                    bitmap_slice[byte_index] |= 1 << bit_index;
+                }
+            }
+        }
+
+        Self { region }
     }
 
 }
@@ -52,23 +84,35 @@ unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
         let mut start_index = None;
         let mut free_count = 0;
 
-        let bitmap = unsafe { self.bitmap.get().as_mut() }.unwrap();
+        // Obtain the bitmap from the region
+        // Size of the bitmap is in the first block
+        let bitmap_size = unsafe {
+            *(self.region.as_ptr() as *const usize)
+        };
+
+        // Get a pointer to the start of the bitmap, the bitmap starts 1 block away from the start
+        let bitmap_ptr = unsafe {
+            (self.region.as_ptr() as *const u8).add(N)
+        };
 
         // Search for a contiguous sequence of free blocks
-        for (index, &bit) in bitmap.iter().enumerate(){
-            for bit_pos in 0..8 {
-                if bit & (1 << bit_pos) == 0 {
-                    free_count += 1;
-                    start_index.get_or_insert(index * 8 + bit_pos);
-                    if free_count >= blocks_required {
-                        // Found a suitable region
-                        break;
+        for i in 0..bitmap_size {
+            unsafe {
+                for j in 0..8 {
+                    let bit = bitmap_ptr.add(i).read() & (1 << j);
+                    if bit == 0 {
+                        free_count += 1;
+                        if free_count == blocks_required {
+                            start_index = Some(i * 8 + j - free_count + 1);
+                            break;
+                        }
+                    } else {
+                        free_count = 0;
                     }
-                } else {
-                    // Reset the counter and start index if a used block is found
-                    start_index = None;
-                    free_count = 0;
                 }
+            }
+            if start_index.is_some() {
+                break;
             }
         }
 
@@ -88,11 +132,13 @@ unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
 
         // Update the bitmap to mark the blocks as used
         unsafe {
-            let bitmap_ptr = self.bitmap.get().as_mut().unwrap(); // Get a mutable reference to the bitmap
+            // Get the bitmap pointer
+            let bitmap_ptr = (self.region.as_ptr() as *mut u8).add(N);
+
             for i in 0..blocks_required {
                 let byte_index = (start_bit + i) / 8;
                 let bit_pos = (start_bit + i) % 8;
-                (*bitmap_ptr)[byte_index] |= 1 << bit_pos;
+                bitmap_ptr.add(byte_index).write(bitmap_ptr.add(byte_index).read() | (1 << bit_pos));
             }
         }
 
@@ -114,25 +160,26 @@ unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
 
         let start_addr = region_slice.as_ptr() as usize; // Start address of the region
 
-        // Checks the bitmap and see if that bit is flipped
-        let bitmap = self.bitmap.get().as_mut().unwrap();
+        // Get a pointer to the start of the bitmap, the bitmap starts 1 block away from the start
+        let bitmap_ptr = (self.region.as_ptr() as *mut u8).add(N);
 
+        // Find out which block it belongs to
         let start_bit = (ptr.as_ptr() as usize - start_addr) / N;
 
         // Sanity check: We should have layout.size() / N blocks starting from start_bit
-        for i in 0..layout.size() / N {
+        for i in 0..layout.size().div_ceil(N) {
             let byte_index = (start_bit + i) / 8;
             let bit_pos = (start_bit + i) % 8;
-            if bitmap[byte_index] & (1 << bit_pos) == 0 {
+            if bitmap_ptr.add(byte_index).read() & (1 << bit_pos) == 0 {
                 panic!("Double free detected");
             }
         }
 
         // Mark the blocks as free
-        for i in 0..layout.size() / N {
+        for i in 0..layout.size().div_ceil(N) {
             let byte_index = (start_bit + i) / 8;
             let bit_pos = (start_bit + i) % 8;
-            bitmap[byte_index] &= !(1 << bit_pos);
+            bitmap_ptr.add(byte_index).write(bitmap_ptr.add(byte_index).read() & !(1 << bit_pos));
         }
     }
 }

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -4,12 +4,12 @@ use core::{
     cell::UnsafeCell,
 };
 
-use alloc::vec::Vec;
+use alloc::boxed::Box;
 use alloc::vec;
 
 pub struct PoolAllocator<const N: usize> {
     region: NonNull<[u8]>,
-    bitmap: UnsafeCell<Vec<u8>>,
+    bitmap: UnsafeCell<Box<[u8]>>,
 }
 
 impl<const N: usize> PoolAllocator<N>{
@@ -22,7 +22,7 @@ impl<const N: usize> PoolAllocator<N>{
         let bitmap_size = (region.len() / N) / 8;
 
         // Initialize the bitmap vector with zeros
-        let bitmap = UnsafeCell::new(vec![0u8; bitmap_size]);
+        let bitmap = UnsafeCell::new(vec![0u8; bitmap_size].into_boxed_slice());
 
         Self { region, bitmap }
     }

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -40,7 +40,7 @@ impl<const N: usize> PoolAllocator<N>{
         unsafe {
             let region_ptr = region.as_ptr();
 
-            // The first block is used to store how large the bitmap is
+            // The first block is used to store how large the bitmap is, in units of bytes
             ptr::write(region_ptr as *mut usize, bitmap_size);
 
             // Initialize the bitmap area to zero, which is 1 block away from the start
@@ -66,7 +66,7 @@ impl<const N: usize> PoolAllocator<N>{
 }
 
 unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         // Can only allocate exactly of size N
         if layout.size() != N {
             return Err(AllocError);
@@ -147,7 +147,7 @@ unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
             NonNull::new(start_addr as *mut u8).unwrap(),
             layout.size());
 
-        let nonnull_slice = NonNull::new(slice_ptr.as_ptr() as *mut [u8]).unwrap();
+        let nonnull_slice = NonNull::new(slice_ptr.as_ptr()).unwrap();
 
         Ok(nonnull_slice)
     }

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -18,6 +18,7 @@ impl<const N: usize> PoolAllocator<N>{
         // Ensure the region is large enough to store at least N bytes,
         // because we're handing out N-byte blocks
         assert!(region.len() >= N);
+        assert!(N.is_power_of_two()); // N must be a power of 2
 
         // Calculate the required bitmap size in bytes, because each stores an u8
 

--- a/src/mem/pool_allocator.rs
+++ b/src/mem/pool_allocator.rs
@@ -15,6 +15,10 @@ pub struct PoolAllocator<const N: usize> {
 impl<const N: usize> PoolAllocator<N>{
     /// PoolAllocator has the giant chunk of memory referred to in region
     pub fn new(region: NonNull<[u8]>) -> Self {
+        // Ensure the region is large enough to store at least N bytes,
+        // because we're handing out N-byte blocks
+        assert!(region.len() >= N);
+
         // Calculate the required bitmap size in bytes, because each stores an u8
 
         // Round up the division to the nearest whole number
@@ -30,13 +34,13 @@ impl<const N: usize> PoolAllocator<N>{
 
 unsafe impl<const N: usize> Allocator for PoolAllocator<N> {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
-        // Ensure the layout size is a multiple of N
-        if layout.size() % N != 0 {
+        // Can only allocate exactly of size N
+        if layout.size() != N {
             return Err(AllocError);
         }
 
         // Check alignment of layout
-        if layout.align() % N != 0 {
+        if layout.align() <= N {
             return Err(AllocError);
         }
 


### PR DESCRIPTION
Got the Pool Allocator's basic implementation done, as instructed and helped by @mtoohey31

Implementation details: 
- Now uses an allocation strategy that is similar to a file system allocation strategy (with blocks of fixed sizes and uses a bitmap to keep track of allocated / deallocated chunks). This is probably valid because we are assuming each block to be only of size `<N>` (parameter passed to Pool Allocator), and we will probably not call `PoolAllocator.allocate()` with some input that is not a multiple of size `N`. 
- Has a bunch of `unsafe` operations (I'm not quite sure how to fix this as I am working with a memory region, and I don't think Rust allows me to do stuff in those region without specifying `unsafe`)

Potential problems:
- Currently the space for the bitmap for the Pool Allocator is not self-contained (Not stored within the region attribute directly), will need to check how to fix that. So it might cause some issues later on. 


We have some other tests by Matthew available in the other branch [feat/pool-allocator-simple-test](https://github.com/KidneyOS/KidneyOS/tree/feat/pool-allocator-simple-test)
(Which I believe should be merged into this branch?)