### PR TITLE
fix memory leak in buddy allocator unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ run-qemu-ng: kidneyos.iso
 
 .PHONY: test
 test:
-	cargo test --target i686-unknown-linux-gnu
+	cargo test --target i686-unknown-linux-gnu --workspace
 
 .PHONY: clean
 clean:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(allocator_api)]
+#![feature(slice_ptr_get)]
 #![cfg_attr(test, feature(btreemap_alloc))]
 #![cfg_attr(target_os = "none", no_std)]
 

--- a/src/mem/buddy_allocator.rs
+++ b/src/mem/buddy_allocator.rs
@@ -222,7 +222,8 @@ mod tests {
 
     #[test]
     fn buddy_allocator_simple() -> Result<(), Box<dyn Error>> {
-        let region = Global.allocate(Layout::from_size_align(2 * KB, 2)?)?;
+        let layout = Layout::from_size_align(2 * KB, 2)?;
+        let region = Global.allocate(layout)?;
         let alloc = unsafe { BuddyAllocator::new(region) };
 
         assert!(alloc.is_empty());
@@ -258,6 +259,8 @@ mod tests {
         drop(m);
 
         assert!(alloc.is_empty());
+
+        unsafe { Global.deallocate(region.as_non_null_ptr(), layout) };
 
         Ok(())
     }


### PR DESCRIPTION
This pull request fixes a memory leak in the buddy allocator unit test. It also fixes the `test` makefile target so it tests both the binary and library tests for the `kidneyos` crate.

Memory leaks are still possible in this unit test when the test fails, but that's probably fine.