### PR TITLE
Hotfix: Properly restore stack pointer in ASM

### DIFF
--- a/kernel/src/sync.rs
+++ b/kernel/src/sync.rs
@@ -102,10 +102,10 @@ pub fn intr_get_level() -> IntrLevel {
     let flags: u32;
     unsafe {
         asm!(
-            "pushf",
-            "pop {0:e}",
-            out(reg) flags,
-            options(nomem, nostack)
+            "pushfd",
+            "mov {0:e}, [esp]",
+            "popfd",
+            out(reg) flags
         );
     }
 


### PR DESCRIPTION
Utilizes the `pushfd` command over the `pushf` command to ensure that our stack pointer is moved by 4 bytes at a time. Uses the `popfd` command to properly restore the stack pointer.