### PR TITLE
Add segment validation for each program header.

### DIFF
--- a/kernel/src/user_program/elf_loader.rs
+++ b/kernel/src/user_program/elf_loader.rs
@@ -64,10 +64,9 @@ pub enum ElfError {
 #[derive(Debug)]
 pub enum ElfSegmentError {
     DifferentPageOffset,
-    OffsetOutOfRange,
+    ContentsOutOfRange,
     MemSizeLesserThanFileSize,
     VMRegionOutOfRange,
-    VMRegionWrapAround,
     PageZeroMapping,
     // Additional error types as needed
 }
@@ -140,10 +139,10 @@ fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> Result<(), ElfSegment
     if (phdr
         .p_offset
         .checked_add(phdr.p_filesz)
-        .ok_or(ElfSegmentError::VMRegionWrapAround)? as usize)
+        .ok_or(ElfSegmentError::ContentsOutOfRange)? as usize)
         > file_data.len()
     {
-        return Err(ElfSegmentError::OffsetOutOfRange);
+        return Err(ElfSegmentError::ContentsOutOfRange);
     }
 
     // p_memsz must be at least as big as p_filesz.
@@ -162,7 +161,7 @@ fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> Result<(), ElfSegment
     if !is_user_vaddr(
         phdr.p_vaddr
             .checked_add(phdr.p_memsz)
-            .ok_or(ElfSegmentError::VMRegionWrapAround)?
+            .ok_or(ElfSegmentError::ContentsOutOfRange)?
             .saturating_sub(1) as *const (),
     ) {
         return Err(ElfSegmentError::VMRegionOutOfRange);

--- a/kernel/src/user_program/elf_loader.rs
+++ b/kernel/src/user_program/elf_loader.rs
@@ -152,7 +152,7 @@ fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> bool {
     }
 
     // Disallow mapping page 0.
-    if (phdr.p_vaddr as usize) < (PAGE_FRAME_SIZE as usize) {
+    if (phdr.p_vaddr as usize) < PAGE_FRAME_SIZE {
         return false;
     }
 

--- a/kernel/src/user_program/elf_loader.rs
+++ b/kernel/src/user_program/elf_loader.rs
@@ -161,7 +161,8 @@ fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> Result<(), ElfSegment
     if !is_user_vaddr(
         phdr.p_vaddr
             .checked_add(phdr.p_memsz)
-            .ok_or(ElfSegmentError::VMRegionWrapAround)? as *const (),
+            .ok_or(ElfSegmentError::VMRegionWrapAround)?
+            .saturating_sub(1) as *const (),
     ) {
         return Err(ElfSegmentError::VMRegionOutOfRange);
     }

--- a/kernel/src/user_program/elf_loader.rs
+++ b/kernel/src/user_program/elf_loader.rs
@@ -59,6 +59,19 @@ pub enum ElfError {
     // Additional error types as needed
 }
 
+// Error types that will arise when we try to validate segment
+#[derive(Debug)]
+pub enum ElfSegmentError {
+    DifferentPageOffset,
+    OffsetOutOfRange,
+    MemSizeLesserThanFileSize,
+    EmptyMemSize,
+    VMRegionOutOfRange,
+    VMRegionWrapAround,
+    PageZeroMapping,
+    // Additional error types as needed
+}
+
 // Flags for p_flags
 const PF_X: u32 = 1; // Executable.
 const PF_W: u32 = 2; // Writable.
@@ -115,49 +128,49 @@ fn is_user_vaddr(vaddr: *const ()) -> bool {
     unsafe { vaddr < PHYS_BASE }
 }
 
-fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> bool {
+fn validate_segment(phdr: &Elf32Phdr, file_data: &[u8]) -> Result<(), ElfSegmentError> {
     // p_offset and p_vaddr must have the same page offset.
     if (phdr.p_offset as usize & PGMASK) != (phdr.p_vaddr as usize & PGMASK) {
-        return false;
+        return Err(ElfSegmentError::DifferentPageOffset);
     }
 
     // p_offset must point within FILE.
     if phdr.p_offset as usize > file_data.len() {
-        return false;
+        return Err(ElfSegmentError::OffsetOutOfRange);
     }
 
     // p_memsz must be at least as big as p_filesz.
     if phdr.p_memsz < phdr.p_filesz {
-        return false;
+        return Err(ElfSegmentError::MemSizeLesserThanFileSize);
     }
 
     // The segment must not be empty.
     if phdr.p_memsz == 0 {
-        return false;
+        return Err(ElfSegmentError::EmptyMemSize);
     }
 
     // The virtual memory region must both start and end within the
     // user address space range.
     if !is_user_vaddr(phdr.p_vaddr as *const ()) {
-        return false;
+        return Err(ElfSegmentError::VMRegionOutOfRange);
     }
     if !is_user_vaddr((phdr.p_vaddr as usize + phdr.p_memsz as usize) as *const ()) {
-        return false;
+        return Err(ElfSegmentError::VMRegionOutOfRange);
     }
 
     // The region cannot "wrap around" across the kernel virtual
     // address space.
     if (phdr.p_vaddr as usize + phdr.p_memsz as usize) < (phdr.p_vaddr as usize) {
-        return false;
+        return Err(ElfSegmentError::VMRegionWrapAround);
     }
 
     // Disallow mapping page 0.
     if (phdr.p_vaddr as usize) < PAGE_FRAME_SIZE {
-        return false;
+        return Err(ElfSegmentError::PageZeroMapping);
     }
 
     // It's okay.
-    true
+    Ok(())
 }
 
 // Main function to load the ELF binary
@@ -180,7 +193,7 @@ fn load_elf(elf_data: &[u8]) -> Result<(), ElfError> {
                 .cast::<Elf32Phdr>()
         };
 
-        if (ph.p_type == SegmentType::Load as u32) && validate_segment(ph, elf_data) {
+        if (ph.p_type == SegmentType::Load as u32) && validate_segment(ph, elf_data).is_ok() {
             let vm_start = ph.p_vaddr as usize;
             let vm_end = vm_start + ph.p_memsz as usize;
 

--- a/kernel/src/user_program/elf_loader.rs
+++ b/kernel/src/user_program/elf_loader.rs
@@ -56,6 +56,7 @@ pub enum ElfError {
     UnsupportedVersion,
     UnsupportedType,
     UnsupportedMachine,
+    SegmentError(ElfSegmentError),
     // Additional error types as needed
 }
 
@@ -193,7 +194,8 @@ fn load_elf(elf_data: &[u8]) -> Result<(), ElfError> {
                 .cast::<Elf32Phdr>()
         };
 
-        if (ph.p_type == SegmentType::Load as u32) && validate_segment(ph, elf_data).is_ok() {
+        if (ph.p_type == SegmentType::Load as u32) {
+            validate_segment(ph, elf_data).map_err(ElfError::SegmentError)?;
             let vm_start = ph.p_vaddr as usize;
             let vm_end = vm_start + ph.p_memsz as usize;
 

--- a/kernel/src/user_program/virtual_memory_area.rs
+++ b/kernel/src/user_program/virtual_memory_area.rs
@@ -1,3 +1,9 @@
+/* The function of the VMA is to define a contiguous area of virtual memory (contiguous virtual addresses) with the correct permissions such as read, write, execute,
+and whether the area is private to the process or shared with others, and the file (if any) that the region is mapped to. Operating systems with virtual memory use VMAs
+to manage memory protection, to share memory between processes, and to lazily allocate memory, among other things. When a binary file, like an ELF executable, is loaded,
+the operating system creates VMAs for its different sections, such as code, data, and BSS segments, according to the program headers in the ELF file.  */
+
+// VmOperations to perform operations related to the VMA (might implement in future).
 #[allow(unused)]
 pub trait VmOperations {
     fn open(&self, area: &VmAreaStruct); // This function is invoked when the given memory area is added to an address space. Such as when it is first set up or when it's inherited during a fork.
@@ -7,6 +13,7 @@ pub trait VmOperations {
 
 pub struct VMAOperations;
 
+// Implementations of VmOperations.
 impl VmOperations for VMAOperations {
     #[allow(unused)]
     fn open(&self, area: &VmAreaStruct) {
@@ -19,6 +26,8 @@ impl VmOperations for VMAOperations {
     }
 }
 
+/* Represents a Virtual Memory Area in an operating system's memory management system.
+It contains fields for the start and end addresses of the VMA, an instance of VmFlags which stores various flags as a bitfield.*/
 pub struct VmAreaStruct {
     pub vm_start: usize, // VMA start, inclusive
     pub vm_end: usize,   // VMA end, exclusive
@@ -26,6 +35,8 @@ pub struct VmAreaStruct {
     // TODO: Add other necessary fields here
 }
 
+/* Stores boolean flags. The flags include read, write, execute, shared, and private, each represented as a single bit.
+This allows the operating system to track the properties and permissions of different memory areas allocated to a process.*/
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct VmFlags {
     pub read: bool,


### PR DESCRIPTION
The function validate_segment() is added, it is responsible for verifying that a segment described by a program header in an ELF file is valid and can be safely loaded into memory for execution.