### PR TITLE
Add code coverage targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c sh -c 'find -name "*.rs" -print0 | xargs -0 rustfmt --quiet --check --'
     - name: Run tests
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}
-      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c make test
+      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c make print-coverage
     - name: Build ISO
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}
       run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c make

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ result
 bx_enh_dbg.ini
 *.core
 /local.mk
+*.profraw
 rustc-ice-*.txt

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -20,8 +20,8 @@
           overlays = [ (import rust-overlay) ];
           inherit system;
         };
-        inherit (pkgs) bochs gdb gnumake mkShell mtools qemu rust-bin unixtools
-          xorriso;
+        inherit (pkgs) bochs gdb gnumake grcov mkShell mtools qemu rust-bin
+          unixtools xorriso;
         inherit (unixtools) xxd;
         rust = rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
         i686-pkgs = import nixpkgs {
@@ -52,6 +52,7 @@
           build = mkShell {
             packages = [
               gnumake
+              grcov
               grub2
               i686-cc
               mtools

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -20,8 +20,8 @@
           overlays = [ (import rust-overlay) ];
           inherit system;
         };
-        inherit (pkgs) bochs gdb gnumake mkShell mtools qemu rust-analyzer
-          rust-bin unixtools xorriso;
+        inherit (pkgs) bochs gdb gnumake mkShell mtools qemu rust-bin unixtools
+          xorriso;
         inherit (unixtools) xxd;
         rust = rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
         i686-pkgs = import nixpkgs {
@@ -72,7 +72,6 @@
             nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
               bochs
               gdb
-              rust-analyzer
               xxd
             ];
           });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2024-01-04"
-components = ["clippy", "llvm-tools-preview", "rustfmt", "rust-src", "rust-std"]
+components = ["clippy", "llvm-tools-preview", "rustfmt", "rust-analyzer", "rust-src", "rust-std"]
 targets = ["i686-unknown-linux-gnu"]
 profile = "minimal"


### PR DESCRIPTION
This merge request adds targets for checking code coverage to our Makefile. It doesn't enforce any specific level of code coverage. I don't think aiming for a certain % makes sense since there are lots of things that we just can't do in tests (for example, anything that requires the CPU to be in kernel mode). I'll add instructions about how to use this to our mdbook documentation once either this or #21 is merged.