### PR TITLE
Add TicketMutex

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,3 +8,7 @@ arbitrary-int = "1.2.7"
 bitbybit = "1.3.0"
 kidneyos-shared.path = "../shared"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+
+[features]
+default = ["ticket_mutex"]
+ticket_mutex = []

--- a/kernel/src/sync/intr.rs
+++ b/kernel/src/sync/intr.rs
@@ -1,70 +1,7 @@
 use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
-// A simple spinlock.
-pub struct SpinLock<T> {
-    lock: AtomicBool,
-    data: UnsafeCell<T>,
-}
-
-// Safety: SpinLock can be safely sent across threads.
-unsafe impl<T> Sync for SpinLock<T> {}
-unsafe impl<T> Send for SpinLock<T> {}
-
-impl<T> SpinLock<T> {
-    #![allow(unused)]
-
-    // Creates a new spinlock.
-    pub const fn new(data: T) -> SpinLock<T> {
-        SpinLock {
-            lock: AtomicBool::new(false),
-            data: UnsafeCell::new(data),
-        }
-    }
-
-    // Acquires the spinlock, spinning until the lock is obtained.
-    pub fn lock(&self) -> SpinLockGuard<T> {
-        while self
-            .lock
-            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            // Spin without locking, to reduce the overhead.
-            // This is a simple busy-wait loop.
-            while self.lock.load(Ordering::Relaxed) {
-                core::hint::spin_loop();
-            }
-        }
-        SpinLockGuard { lock: self }
-    }
-}
-
-// A guard that provides access to the data protected by the `SpinLock`.
-// When the guard is dropped, the lock is released.
-pub struct SpinLockGuard<'a, T> {
-    lock: &'a SpinLock<T>,
-}
-
-impl<T> Deref for SpinLockGuard<'_, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.lock.data.get() }
-    }
-}
-
-impl<T> DerefMut for SpinLockGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.lock.data.get() }
-    }
-}
-
-impl<T> Drop for SpinLockGuard<'_, T> {
-    fn drop(&mut self) {
-        self.lock.lock.store(false, Ordering::Release);
-    }
-}
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 static INTR_DISABLE_COUNT: AtomicUsize = AtomicUsize::new(0);
 

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,0 +1,3 @@
+pub mod intr;
+#[allow(unused)]
+pub mod mutex;

--- a/kernel/src/sync/mutex.rs
+++ b/kernel/src/sync/mutex.rs
@@ -1,10 +1,17 @@
 pub mod ticket;
 pub use self::ticket::{TicketMutex, TicketMutexGuard};
 
+#[cfg(feature = "ticket_mutex")]
 type InnerMutex<T> = TicketMutex<T>;
+#[cfg(feature = "ticket_mutex")]
 type InnerMutexGuard<'a, T> = TicketMutexGuard<'a, T>;
 
-/// A locak that provides mutually exclusive data access.
+#[cfg(not(feature = "ticket_mutex"))]
+type InnerMutex<T> = TicketMutex<T>;
+#[cfg(not(feature = "ticket_mutex"))]
+type InnerMutexGuard<'a, T> = TicketMutexGuard<'a, T>;
+
+/// A lock that provides mutually exclusive data access.
 pub struct Mutex<T: ?Sized> {
     inner: InnerMutex<T>,
 }

--- a/kernel/src/sync/mutex.rs
+++ b/kernel/src/sync/mutex.rs
@@ -1,0 +1,52 @@
+pub mod ticket;
+pub use self::ticket::{TicketMutex, TicketMutexGuard};
+
+type InnerMutex<T> = TicketMutex<T>;
+type InnerMutexGuard<'a, T> = TicketMutexGuard<'a, T>;
+
+/// A locak that provides mutually exclusive data access.
+pub struct Mutex<T: ?Sized> {
+    inner: InnerMutex<T>,
+}
+
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+
+/// A guard that provides mutable data access.
+pub struct MutexGuard<'a, T: 'a + ?Sized> {
+    inner: InnerMutexGuard<'a, T>,
+}
+
+impl<T> Mutex<T> {
+    #[inline(always)]
+    pub const fn new(value: T) -> Self {
+        Self {
+            inner: InnerMutex::new(value),
+        }
+    }
+
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    #[inline(always)]
+    pub fn lock(&self) -> MutexGuard<T> {
+        MutexGuard {
+            inner: self.inner.lock(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_locked(&self) -> bool {
+        self.inner.is_locked()
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+        self.inner
+            .try_lock()
+            .map(|guard| MutexGuard { inner: guard })
+    }
+}

--- a/kernel/src/sync/mutex/ticket.rs
+++ b/kernel/src/sync/mutex/ticket.rs
@@ -1,0 +1,155 @@
+//! A ticket-based mutex based on [spin](https://docs.rs/spin/latest/spin/).
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+/// A [spinning mutex](https://en.m.wikipedia.org/wiki/Spinlock) with [ticketing](https://en.wikipedia.org/wiki/Ticket_lock).
+///
+/// A first-in-first-out ticketing queue: the thread that started waiting first gets the lock first.
+///
+/// # Example
+///
+/// ```
+/// let lock = sync::mutex::TicketMutex::<_>::new(0);
+///
+/// *lock.lock() = 1;
+/// assert_eq!(*lock.lock(), 1);
+/// ```
+pub struct TicketMutex<T: ?Sized> {
+    next_ticket: AtomicUsize,
+    next_serving: AtomicUsize,
+    data: UnsafeCell<T>,
+}
+
+/// A guard that provides access to the data protected by the mutex.
+///
+/// When the guard is dropped, the lock is released.
+pub struct TicketMutexGuard<'a, T: ?Sized + 'a> {
+    next_serving: &'a AtomicUsize,
+    ticket: usize,
+    data: &'a mut T,
+}
+
+// Same unsafe impls as `std::sync::Mutex`
+unsafe impl<T: ?Sized + Send> Sync for TicketMutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for TicketMutex<T> {}
+
+unsafe impl<T: ?Sized + Sync> Sync for TicketMutexGuard<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for TicketMutexGuard<'_, T> {}
+
+impl<T> TicketMutex<T> {
+    #[inline(always)]
+    pub const fn new(data: T) -> Self {
+        Self {
+            next_ticket: AtomicUsize::new(0),
+            next_serving: AtomicUsize::new(0),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.data.into_inner()
+    }
+
+    #[inline(always)]
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.data.get()
+    }
+}
+
+impl<T: ?Sized> TicketMutex<T> {
+    #[inline(always)]
+    pub fn lock(&self) -> TicketMutexGuard<T> {
+        let ticket = self.next_ticket.fetch_add(1, Ordering::Relaxed);
+
+        while self.next_serving.load(Ordering::Acquire) != ticket {
+            core::hint::spin_loop();
+        }
+
+        TicketMutexGuard {
+            next_serving: &self.next_serving,
+            ticket,
+            data: unsafe { &mut *self.data.get() },
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_locked(&self) -> bool {
+        let ticket = self.next_ticket.load(Ordering::Relaxed);
+        self.next_serving.load(Ordering::Relaxed) != ticket
+    }
+
+    #[inline(always)]
+    pub fn try_lock(&self) -> Option<TicketMutexGuard<T>> {
+        let ticket = self
+            .next_ticket
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |ticket| {
+                if self.next_serving.load(Ordering::Acquire) == ticket {
+                    Some(ticket + 1)
+                } else {
+                    None
+                }
+            });
+
+        ticket.ok().map(|ticket| TicketMutexGuard {
+            next_serving: &self.next_serving,
+            ticket,
+            data: unsafe { &mut *self.data.get() },
+        })
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.data.get() }
+    }
+}
+
+impl<T: ?Sized + Default> Default for TicketMutex<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T> From<T> for TicketMutex<T> {
+    fn from(data: T) -> Self {
+        Self::new(data)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for TicketMutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for TicketMutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized> Deref for TicketMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.data
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for TicketMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.data
+    }
+}
+
+impl<'a, T: ?Sized> Drop for TicketMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        let new_ticket = self.ticket + 1;
+        self.next_serving.store(new_ticket, Ordering::Release);
+    }
+}

--- a/kernel/src/threading/context_switch.rs
+++ b/kernel/src/threading/context_switch.rs
@@ -1,4 +1,4 @@
-use crate::sync::{intr_get_level, IntrLevel};
+use crate::sync::intr::{intr_get_level, IntrLevel};
 use core::mem::offset_of;
 
 use alloc::boxed::Box;

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -5,7 +5,7 @@ mod thread_functions;
 
 use crate::{
     paging::PageManager,
-    sync::{intr_enable, intr_get_level, IntrLevel},
+    sync::intr::{intr_enable, intr_get_level, IntrLevel},
 };
 use alloc::boxed::Box;
 use kidneyos_shared::println;

--- a/kernel/src/threading/scheduling/mod.rs
+++ b/kernel/src/threading/scheduling/mod.rs
@@ -6,7 +6,7 @@ pub use scheduler::Scheduler;
 
 use alloc::boxed::Box;
 
-use crate::sync::{intr_disable, intr_enable, intr_get_level, IntrLevel};
+use crate::sync::intr::{intr_disable, intr_enable, intr_get_level, IntrLevel};
 
 use super::{context_switch::switch_threads, thread_control_block::ThreadStatus};
 

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -3,7 +3,7 @@ use super::{
     thread_control_block::{ThreadControlBlock, ThreadStatus},
     RUNNING_THREAD,
 };
-use crate::sync::intr_enable;
+use crate::sync::intr::intr_enable;
 use core::arch::asm;
 use kidneyos_shared::{
     global_descriptor_table::{USER_CODE_SELECTOR, USER_DATA_SELECTOR},


### PR DESCRIPTION
`TicketMutex` grants the lock to the first thread that requested it. Also added `Mutex` providing an abstraction over the type of the mutex we use, which is enabled through a cfg directive.