### PR TITLE
Enables timer interrupts and adds a system clock

### DIFF
--- a/kernel/src/interrupt_descriptor_table.rs
+++ b/kernel/src/interrupt_descriptor_table.rs
@@ -7,6 +7,9 @@ use arbitrary_int::{u2, u4};
 use bitbybit::bitfield;
 use core::{arch::asm, mem::size_of};
 
+use crate::pic;
+use crate::threading::scheduling;
+
 #[repr(align(8))]
 #[bitfield(u64, default = 0)]
 struct GateDescriptor {
@@ -93,6 +96,24 @@ unsafe extern "C" fn syscall_handler() -> ! {
     );
 }
 
+#[naked]
+unsafe extern "C" fn timer_interrupt_handler() -> ! {
+    asm!(
+        "
+        // Push IRQ0 value onto the stack.
+        push 0x0
+        call {} // Send EOI signal to PICs
+        call {} // Yield process
+
+        add esp, 4 // Drop arguments from stack
+        iretd
+        ",
+        sym pic::send_eoi,
+        sym scheduling::scheduler_yield_and_continue,
+        options(noreturn),
+    );
+}
+
 static mut IDT_DESCRIPTOR: IDTDescriptor = IDTDescriptor {
     size: size_of::<[GateDescriptor; IDT_LEN]>() as u16 - 1,
     offset: 0, // Will fetch pointer and set at runtime below.
@@ -113,7 +134,8 @@ pub unsafe fn load() {
             .with_descriptor_privilege_level(u2::new(3))
             .with_present(true);
     }
-    IDT[0xE] = IDT[0xE].with_offset(page_fault_handler as usize as u32);
+    IDT[0xe] = IDT[0xe].with_offset(page_fault_handler as usize as u32);
+    IDT[0x20] = IDT[0x20].with_offset(timer_interrupt_handler as usize as u32); // PIC1_OFFSET (IRQ0)
     IDT[0x80] = IDT[0x80].with_offset(syscall_handler as usize as u32);
 
     asm!("lidt [{}]", sym IDT_DESCRIPTOR);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -11,6 +11,7 @@
 mod interrupt_descriptor_table;
 mod mem;
 mod paging;
+mod pic;
 mod sync;
 mod threading;
 mod user_program;
@@ -54,6 +55,11 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
         println!("Setting up GDTR");
         global_descriptor_table::load();
         println!("GDTR set up!");
+
+        println!("Setting up PIT");
+        pic::pic_remap(pic::PIC1_OFFSET, pic::PIC2_OFFSET);
+        pic::init_pit();
+        println!("PIT set up!");
 
         println!("Initializing Thread System...");
         thread_system_initialization();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -11,9 +11,9 @@
 mod interrupt_descriptor_table;
 mod mem;
 mod paging;
-mod pic;
 mod sync;
 mod threading;
+mod timer;
 mod user_program;
 
 extern crate alloc;
@@ -57,8 +57,8 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
         println!("GDTR set up!");
 
         println!("Setting up PIT");
-        pic::pic_remap(pic::PIC1_OFFSET, pic::PIC2_OFFSET);
-        pic::init_pit();
+        timer::pic_remap(timer::PIC1_OFFSET, timer::PIC2_OFFSET);
+        timer::init_pit();
         println!("PIT set up!");
 
         println!("Initializing Thread System...");

--- a/kernel/src/pic.rs
+++ b/kernel/src/pic.rs
@@ -1,0 +1,96 @@
+use core::arch::asm;
+use kidneyos_shared::serial::{inb, outb};
+
+pub const PIC1_OFFSET: u8 = 0x20;
+pub const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
+
+const PIC1_CMD: u16 = 0x20;
+const PIC1_DATA: u16 = 0x21;
+const PIC2_CMD: u16 = 0xa0;
+const PIC2_DATA: u16 = 0xa1;
+
+const ICW1_ICW4: u8 = 0x01; /* Indicates that ICW4 will be present */
+const ICW1_INIT: u8 = 0x10; /* Initialization - required! */
+const ICW4_8086: u8 = 0x01; /* 8086/88 (MCS-80/85) mode */
+
+const PIC_EOI: u8 = 0x20; /* End-of-interrupt command code */
+
+pub unsafe fn pic_remap(offset1: u8, offset2: u8) {
+    // Send command: Begin 3-byte initialization sequence.
+    outb(PIC1_CMD, ICW1_INIT + ICW1_ICW4);
+    io_wait();
+    outb(PIC2_CMD, ICW1_INIT + ICW1_ICW4);
+    io_wait();
+
+    // Send data 1: Set interrupt offset.
+    outb(PIC1_DATA, offset1);
+    io_wait();
+    outb(PIC2_DATA, offset2);
+    io_wait();
+
+    // Byte 2: Configure chaining between PIC1 and PIC2.
+    outb(PIC1_DATA, 4);
+    io_wait();
+    outb(PIC2_DATA, 2);
+    io_wait();
+
+    // Send data 3: Set mode.
+    outb(PIC1_DATA, ICW4_8086);
+    io_wait();
+    outb(PIC2_DATA, ICW4_8086);
+    io_wait();
+}
+
+pub unsafe fn init_pit() {
+    // program the PIT
+    // channel 0 (bit 6-7), lo/hi-byte (bit 4-5), rate generator (bit 1-3)
+    outb(0x43, 0b00110100);
+
+    asm!(
+        "
+        mov ax, 0xffffffff // reload value
+        out 0x40, al // set low byte of PIT reload value
+        mov al, ah
+        out 0x40, al // set high byte of PIT reload value
+        ",
+    );
+
+    // unmask and activate all IRQs
+    outb(PIC1_DATA, 0x0);
+    outb(PIC2_DATA, 0x0);
+}
+
+#[allow(unused)]
+pub unsafe fn irq_mask(mut irq: u8) {
+    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
+    if irq >= 8 {
+        irq -= 8
+    };
+    let mask = inb(port) | (1 << irq);
+
+    outb(port, mask);
+}
+
+#[allow(unused)]
+pub unsafe fn irq_unmask(mut irq: u8) {
+    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
+    if irq >= 8 {
+        irq -= 8
+    };
+    let mask = inb(port) & !(1 << irq);
+
+    outb(port, mask);
+}
+
+pub unsafe fn send_eoi(irq: u8) {
+    if irq >= 8 {
+        outb(PIC2_CMD, PIC_EOI);
+    }
+
+    outb(PIC1_CMD, PIC_EOI);
+}
+
+unsafe fn io_wait() {
+    // http://wiki.osdev.org/Inline_Assembly/Examples#IO_WAIT
+    outb(0x80, 0);
+}

--- a/kernel/src/sync/mutex/ticket.rs
+++ b/kernel/src/sync/mutex/ticket.rs
@@ -4,7 +4,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{
     cell::UnsafeCell,
     fmt,
-    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 

--- a/kernel/src/threading/scheduling/mod.rs
+++ b/kernel/src/threading/scheduling/mod.rs
@@ -22,19 +22,39 @@ pub fn initialize_scheduler() {
 }
 
 /// Voluntarily relinquishes control of the CPU to another processor in the scheduler.
-pub fn scheduler_yield() {
+fn scheduler_yield(status_for_current_thread: ThreadStatus) {
     intr_disable();
 
     // SAFETY: Threads and Scheduler must be initialized and active.
     // Interrupts must be disabled.
     unsafe {
         let scheduler = SCHEDULER.as_mut().expect("No Scheduler set up!");
-        let switch_to = scheduler.pop().expect("No threads to run!");
+        let switch_to_option = scheduler.pop();
 
-        // Switch to this other thread.
-        // Since this is a voluntary switch, the current thread will be ready to run again.
-        switch_threads(ThreadStatus::Ready, switch_to);
+        // Do not switch to ourselves.
+        if let Some(switch_to) = switch_to_option {
+            // Switch to this other thread.
+            switch_threads(status_for_current_thread, switch_to);
+        }
     }
 
     intr_enable();
+}
+
+// Voluntarily relinquishes control of the CPU and marks current thread as ready.
+pub fn scheduler_yield_and_continue() {
+    scheduler_yield(ThreadStatus::Ready);
+}
+
+/// Voluntarily relinquishes control of the CPU and marks the current thread to die.
+pub fn scheduler_yield_and_die() -> ! {
+    scheduler_yield(ThreadStatus::Dying);
+
+    panic!("A thread was rescheduled after dying.");
+}
+
+/// Voluntarily relinquishes control of the CPU and marks the current thread as blocked.
+#[allow(unused)]
+pub fn scheduler_yield_and_block() {
+    scheduler_yield(ThreadStatus::Blocked);
 }

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -1,14 +1,16 @@
 use super::{
-    scheduling::{scheduler_yield, SCHEDULER},
+    scheduling::SCHEDULER,
     thread_control_block::{ThreadControlBlock, ThreadStatus},
     RUNNING_THREAD,
 };
-use crate::sync::intr::intr_enable;
+use crate::{
+    sync::intr::{intr_disable, intr_enable},
+    threading::scheduling::scheduler_yield_and_die,
+};
 use alloc::boxed::Box;
 use core::arch::asm;
 use kidneyos_shared::{
     global_descriptor_table::{USER_CODE_SELECTOR, USER_DATA_SELECTOR},
-    serial::outb,
     task_state_segment::TASK_STATE_SEGMENT,
 };
 
@@ -16,16 +18,26 @@ use kidneyos_shared::{
 /// No arguments allowed for now.
 ///
 /// A function that may be used for thread creation.
-pub type ThreadFunction = unsafe extern "C" fn() -> ();
+/// The return value will be the exit code of this thread.
+pub type ThreadFunction = unsafe extern "C" fn() -> i32;
 
-/// A function to safely close a thread.
+/// A function to safely close the current thread.
+/// This is safe to call at any point in a threads runtime.
 #[allow(unused)]
-const fn exit_thread() -> ! {
-    // TODO: Need to reap TCB, remove from scheduling.
+pub fn exit_thread(exit_code: i32) -> ! {
+    // We will never return here so do not need to re-enable interrupts from here.
+    intr_disable();
 
-    // Relinquish CPU to another thread.
-    // TODO:
-    panic!("Thread exited incorrectly.");
+    // Get the current thread.
+    // SAFETY: Interrupts must be off.
+    unsafe {
+        let mut current_thread = RUNNING_THREAD.take().expect("Why is nothing running!?");
+        current_thread.set_exit_code(exit_code);
+
+        // Replace and yield.
+        RUNNING_THREAD = Some(current_thread);
+        scheduler_yield_and_die();
+    }
 }
 
 /// A wrapper function to execute a thread's true function.
@@ -45,24 +57,34 @@ unsafe extern "C" fn run_thread(
 
     // Reschedule our threads.
     RUNNING_THREAD = Some(switched_to);
-    SCHEDULER
-        .as_mut()
-        .expect("Scheduler not set up!")
-        .push(Box::from_raw(switched_from));
+
+    let mut switched_from = Box::from_raw(switched_from);
+
+    if switched_from.status == ThreadStatus::Dying {
+        switched_from.reap();
+
+        // Page manager must be loaded to be dropped.
+        switched_from.page_manager.load();
+        drop(switched_from);
+        RUNNING_THREAD.as_ref().unwrap().page_manager.load();
+    } else {
+        SCHEDULER
+            .as_mut()
+            .expect("Scheduler not set up!")
+            .push(switched_from);
+    }
 
     // Our scheduler will operate without interrupts.
     // Every new thread should start with them enabled.
-    outb(0x21, 0xfd);
-    outb(0xa1, 0xff);
     intr_enable();
 
     // Kernel threads have no associated PCB, denoted by its PID being 0
     if pid == 0 {
-        let entry_function = eip.as_ptr() as *const fn();
-        (*entry_function)();
-        loop {
-            scheduler_yield();
-        }
+        let entry_function = eip.as_ptr() as *const ThreadFunction;
+        let exit_code = (*entry_function)();
+
+        // Safely exit the thread.
+        exit_thread(exit_code);
     } else {
         // https://wiki.osdev.org/Getting_to_Ring_3#iret_method
         // https://web.archive.org/web/20160326062442/http://jamesmolloy.co.uk/tutorial_html/10.-User%20Mode.html
@@ -75,10 +97,10 @@ unsafe extern "C" fn run_thread(
 
             // Set up the stack frame iret expects.
             push {data_sel:e} // stack segment
-            push {esp} // esp
+            push {esp}
             pushfd // eflags
             push {code_sel} // code segment
-            push {eip} // eip
+            push {eip}
             iretd
             ",
             data_sel = in(reg) USER_DATA_SELECTOR,
@@ -90,20 +112,21 @@ unsafe extern "C" fn run_thread(
     }
 }
 
+#[allow(unused)]
 #[repr(C, packed)]
 pub struct PrepareThreadContext {
-    entry_function: ThreadFunction,
+    entry_function: *const u8,
 }
 
 impl PrepareThreadContext {
-    pub fn new(entry_function: ThreadFunction) -> Self {
+    pub fn new(entry_function: *const u8) -> Self {
         Self { entry_function }
     }
 }
 
 /// This function is used to clean up a thread's arguments and call into `run_thread`.
 #[naked]
-unsafe extern "C" fn prepare_thread() {
+unsafe extern "C" fn prepare_thread() -> i32 {
     // Since this function is only to be called from the `context_switch` function, we expect
     // That %eax and %edx contain the arguments passed to it.
     // Further, the entry function pointer is at a known position on the stack.

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -1,26 +1,37 @@
 // https://docs.google.com/document/d/1qMMU73HW541wME00Ngl79ou-kQ23zzTlGXJYo9FNh5M
 
+use crate::threading::scheduling::scheduler_yield_and_continue;
+use crate::threading::thread_functions;
 use kidneyos_shared::println;
 
 /// This function is responsible for processing syscalls made by user programs.
-/// Its return value is the syscall return value, whose meaning depends on the
-/// syscall. It might not actually return sometimes, such as when the syscall
-/// is exit.
+/// Its return value is the syscall return value, whose meaning depends on the syscall.
+/// It might not actually return sometimes, such as when the syscall is exit.
 pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2: usize) -> usize {
     println!("syscall number {syscall_number:#X} with arguments: {arg0:#X} {arg1:#X} {arg2:#X}");
-    // TODO: Start implementing this by branching on syscall_number. Add
-    // todo!()'s for any syscalls that aren't implemented. Return an error if an
-    // invalid syscall number is provided.
+    // TODO: Start implementing this by branching on syscall_number.
+    // Add todo!()'s for any syscalls that aren't implemented.
+    // Return an error if an invalid syscall number is provided.
     // Translate between syscall names and numbers: https://x86.syscall.sh/
     match syscall_number {
         SYS_EXIT => {
-            todo!("exit syscall")
+            thread_functions::exit_thread(arg0 as i32);
         }
         SYS_FORK => {
             todo!("fork syscall")
         }
-        0x7 => {
+        SYS_READ => {
+            todo!("read syscall")
+        }
+        SYS_WAITPID => {
             todo!("waitpid syscall")
+        }
+        SYS_NANOSLEEP => {
+            todo!("nanosleep syscall")
+        }
+        SYS_SCHED_YIELD => {
+            scheduler_yield_and_continue();
+            0
         }
         _ => 1,
     }
@@ -28,3 +39,7 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
 
 pub const SYS_EXIT: usize = 0x1;
 pub const SYS_FORK: usize = 0x2;
+pub const SYS_READ: usize = 0x3;
+pub const SYS_WAITPID: usize = 0x7;
+pub const SYS_NANOSLEEP: usize = 0xa2;
+pub const SYS_SCHED_YIELD: usize = 0x9e;

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -4,6 +4,13 @@ use crate::threading::scheduling::scheduler_yield_and_continue;
 use crate::threading::thread_functions;
 use kidneyos_shared::println;
 
+pub const SYS_EXIT: usize = 0x1;
+pub const SYS_FORK: usize = 0x2;
+pub const SYS_READ: usize = 0x3;
+pub const SYS_WAITPID: usize = 0x7;
+pub const SYS_NANOSLEEP: usize = 0xa2;
+pub const SYS_SCHED_YIELD: usize = 0x9e;
+
 /// This function is responsible for processing syscalls made by user programs.
 /// Its return value is the syscall return value, whose meaning depends on the syscall.
 /// It might not actually return sometimes, such as when the syscall is exit.
@@ -36,10 +43,3 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
         _ => 1,
     }
 }
-
-pub const SYS_EXIT: usize = 0x1;
-pub const SYS_FORK: usize = 0x2;
-pub const SYS_READ: usize = 0x3;
-pub const SYS_WAITPID: usize = 0x7;
-pub const SYS_NANOSLEEP: usize = 0xa2;
-pub const SYS_SCHED_YIELD: usize = 0x9e;

--- a/shared/src/paging.rs
+++ b/shared/src/paging.rs
@@ -231,12 +231,14 @@ impl<A: Allocator> PageManager<A> {
     /// there's nothing in the TLB for the virtual addresses included in this
     /// mapping, the mapping may take effect without the call to `load`.
     pub unsafe fn map(&mut self, phys_addr: usize, virt_addr: usize, write: bool, user: bool) {
-        assert!(
-            phys_addr % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            phys_addr % PAGE_FRAME_SIZE,
+            0,
             "phys_addr was not page-frame-aligned"
         );
-        assert!(
-            virt_addr % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            virt_addr % PAGE_FRAME_SIZE,
+            0,
             "virt_addr was not page-frame-aligned"
         );
 
@@ -298,12 +300,14 @@ impl<A: Allocator> PageManager<A> {
     /// Same as `map`.
     pub unsafe fn huge_map(&mut self, phys_addr: usize, virt_addr: usize, write: bool, user: bool) {
         assert!(*PSE_ENABLED, "PSE was not enabled");
-        assert!(
-            phys_addr % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            phys_addr % PAGE_FRAME_SIZE,
+            0,
             "phys_addr was not page-frame-aligned"
         );
-        assert!(
-            virt_addr % HUGE_PAGE_SIZE == 0,
+        assert_eq!(
+            virt_addr % HUGE_PAGE_SIZE,
+            0,
             "virt_addr was not properly aligned"
         );
 
@@ -343,16 +347,19 @@ impl<A: Allocator> PageManager<A> {
         write: bool,
         user: bool,
     ) {
-        assert!(
-            phys_start % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            phys_start % PAGE_FRAME_SIZE,
+            0,
             "phys_start was not page-frame-aligned"
         );
-        assert!(
-            virt_start % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            virt_start % PAGE_FRAME_SIZE,
+            0,
             "virt_start was not page-frame-aligned"
         );
-        assert!(
-            len % PAGE_FRAME_SIZE == 0,
+        assert_eq!(
+            len % PAGE_FRAME_SIZE,
+            0,
             "len was not a multiple of PAGE_FRAME_SIZE"
         );
 

--- a/shared/src/serial.rs
+++ b/shared/src/serial.rs
@@ -20,7 +20,10 @@ pub unsafe fn outb(port: u16, byte: u8) {
     asm!("out dx, al", in("dx") port, in("al") byte)
 }
 
-unsafe fn inb(port: u16) -> u8 {
+/// # Safety
+///
+/// Wrapper for the assembly function in.
+pub unsafe fn inb(port: u16) -> u8 {
     let res: u8;
     asm!("in al, dx", in("dx") port, out("al") res);
     res
@@ -51,8 +54,8 @@ impl SerialWriter {
             const EXPECTED: u8 = 0xAE;
             outb(THR, EXPECTED);
             let actual = inb(RBR);
-            assert!(
-                actual == EXPECTED,
+            assert_eq!(
+                actual, EXPECTED,
                 "faulty serial, expected {EXPECTED:#X}, got {actual:#X}"
             );
 


### PR DESCRIPTION
Enables timer interrupts by programming the PICs and PIT when initializing the OS. Uses this to implement a coarse system clock and a simple `sleep` (kernel) function.