### PR TITLE
Add irq safe mutex and interrupts guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 result
 /.direnv
 
+/target/
 /build/
 bx_enh_dbg.ini
 *.core
 /local.mk
 *.profraw
 rustc-ice-*.txt
+kidneyos-builder.tar.gz
+.DS_Store

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -7,6 +7,7 @@
 #![feature(slice_ptr_get)]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(not(test), no_main)]
+#![feature(negative_impls)]
 
 mod interrupt_descriptor_table;
 mod mem;

--- a/kernel/src/sync/irq.rs
+++ b/kernel/src/sync/irq.rs
@@ -1,0 +1,100 @@
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
+
+use super::intr::{hold_interrupts, InterruptsGuard};
+
+use crate::sync::mutex::{Mutex, MutexGuard};
+
+pub struct MutexIrq<T: ?Sized> {
+    lock: Mutex<T>,
+}
+
+pub struct MutexGuardIrq<'a, T: ?Sized + 'a> {
+    guard: MutexGuard<'a, T>,
+    _guard: InterruptsGuard,
+}
+
+// Same unsafe impls as `std::sync::MutexIrqSafe`
+unsafe impl<T: ?Sized + Send> Sync for MutexIrq<T> {}
+unsafe impl<T: ?Sized + Send> Send for MutexIrq<T> {}
+
+impl<T> MutexIrq<T> {
+    pub const fn new(data: T) -> MutexIrq<T> {
+        MutexIrq {
+            lock: Mutex::new(data),
+        }
+    }
+
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.lock.into_inner()
+    }
+}
+
+impl<T: ?Sized> MutexIrq<T> {
+    #[inline(always)]
+    pub fn lock(&self) -> MutexGuardIrq<T> {
+        loop {
+            if let Some(guard) = self.try_lock() {
+                return guard;
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_locked(&self) -> bool {
+        self.lock.is_locked()
+    }
+
+    pub unsafe fn force_unlock(&self) {
+        self.lock.force_unlock()
+    }
+
+    #[inline(always)]
+    pub fn try_lock(&self) -> Option<MutexGuardIrq<T>> {
+        if self.lock.is_locked() {
+            return None;
+        }
+        let _held_irq = hold_interrupts();
+        self.lock.try_lock().map(|guard| MutexGuardIrq {
+            guard,
+            _guard: _held_irq,
+        })
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.lock.get_mut()
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexIrq<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.lock.try_lock() {
+            Some(guard) => write!(f, "MutexIrq {{ data: {:?} }}", &*guard),
+            None => write!(f, "MutexIrq {{ <locked> }}"),
+        }
+    }
+}
+
+impl<T: ?Sized + Default> Default for MutexIrq<T> {
+    fn default() -> MutexIrq<T> {
+        MutexIrq::new(Default::default())
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MutexGuardIrq<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &(self.guard)
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MutexGuardIrq<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.guard
+    }
+}

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,3 +1,5 @@
 pub mod intr;
 #[allow(unused)]
+pub mod irq;
+#[allow(unused)]
 pub mod mutex;

--- a/kernel/src/sync/mutex.rs
+++ b/kernel/src/sync/mutex.rs
@@ -1,5 +1,9 @@
 pub mod ticket;
 pub use self::ticket::{TicketMutex, TicketMutexGuard};
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 #[cfg(feature = "ticket_mutex")]
 type InnerMutex<T> = TicketMutex<T>;
@@ -47,13 +51,74 @@ impl<T: ?Sized> Mutex<T> {
     }
 
     #[inline(always)]
+    pub unsafe fn force_unlock(&self) {
+        self.inner.force_unlock()
+    }
+
+    #[inline(always)]
     pub fn is_locked(&self) -> bool {
         self.inner.is_locked()
     }
 
+    #[inline(always)]
     pub fn try_lock(&self) -> Option<MutexGuard<T>> {
         self.inner
             .try_lock()
             .map(|guard| MutexGuard { inner: guard })
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    fn from(data: T) -> Self {
+        Self::new(data)
+    }
+}
+
+impl<'a, T: ?Sized> MutexGuard<'a, T> {
+    #[inline(always)]
+    pub fn leak(this: Self) -> &'a mut T {
+        InnerMutexGuard::leak(this.inner)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
     }
 }

--- a/kernel/src/threading/scheduling/mod.rs
+++ b/kernel/src/threading/scheduling/mod.rs
@@ -6,7 +6,7 @@ pub use scheduler::Scheduler;
 
 use alloc::boxed::Box;
 
-use crate::sync::intr::{intr_disable, intr_enable, intr_get_level, IntrLevel};
+use crate::sync::intr::{hold_interrupts, intr_get_level, IntrLevel};
 
 use super::{context_switch::switch_threads, thread_control_block::ThreadStatus};
 
@@ -23,7 +23,7 @@ pub fn initialize_scheduler() {
 
 /// Voluntarily relinquishes control of the CPU to another processor in the scheduler.
 fn scheduler_yield(status_for_current_thread: ThreadStatus) {
-    intr_disable();
+    let _guard = hold_interrupts();
 
     // SAFETY: Threads and Scheduler must be initialized and active.
     // Interrupts must be disabled.
@@ -38,7 +38,7 @@ fn scheduler_yield(status_for_current_thread: ThreadStatus) {
         }
     }
 
-    intr_enable();
+    // Note: _guard falls out of scope and re-enables interrupts if previously enabled
 }
 
 // Voluntarily relinquishes control of the CPU and marks current thread as ready.


### PR DESCRIPTION
Adds `MutexIrq` and an interrupt guard so that the user doesn't have to disable the held guard and it'll drop when it falls out of scope. 