### PR TITLE
Use cross compile ar instead of system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ $(RAW_TRAMPOLINE): trampoline/Cargo.toml Cargo.lock
 $(TRAMPOLINE_DIR)/libkidneyos_trampoline: $(RAW_TRAMPOLINE)
 	rm -rf $@
 	mkdir -p $@
-	ar x $< --output=$@
+	i686-unknown-linux-gnu-ar x $< --output=$@
 
 $(TRAMPOLINE_DIR)/libkidneyos_trampoline_unlocalized.o: $(TRAMPOLINE_DIR)/libkidneyos_trampoline
 	i686-unknown-linux-gnu-ld -r -o $@ $</*.o


### PR DESCRIPTION
On macOS, the system `ar` doesn't play nice with our provided `ar` command (not sure if that's a command syntax issue or  an architecture issue). We should use the cross-compile `ar` explicitly instead. Building with Docker + nix still works.

Apart from that, you can build on macOS by installing these dependencies:
```sh
# Step 1: Install you cross compiler (https://github.com/messense/homebrew-macos-cross-toolchains)
brew tap messense/macos-cross-toolchains
brew install i686-unknown-linux-gnu

# And that's it! You can build the kernel binary now via `make`.
# But if you want to build the ISO you have to do a complicated dance (building grub from source).
 
# Step 2: Download grub dependencies.
brew install objconv # Required to build by grub
brew install autoconf automake pkg-config # Unsure if needed but they are installed on my system.
brew install gawk # macOS awk doesn't work nicely with the grub install scripts
brew install xorriso # grub-mkrescue invokes this to create the ISO

# Step 3: Alias gawk
# https://gist.github.com/emkay/a1214c753e8c975d95b4?permalink_comment_id=4612920#gistcomment-4612920
# `alias awk=gawk` is in my .zshrc, you can remove it after you build if you'd like, not sure if it works inline
echo "alias awk=gawk" >> ~/.zshrc

# Step 4: Build and Install Grub
git clone git://git.savannah.gnu.org/grub.git
cd grub

./bootstrap # Configures some things.
./autogen.sh # Didn't seem to need to run this, but just in case.

mkdir build
cd build

../configure --disable-werror TARGET_CC=i686-unknown-linux-gnu-gcc TARGET_OBJCOPY=i686-unknown-linux-gnu-objcopy \
    TARGET_STRIP=i686-unknown-linux-gnu-strip TARGET_NM=i686-unknown-linux-gnu-nm TARGET_RANLIB=i686-unknown-linux-gnu-ranlib --target=i686-unknown-linux-gnu
    
make

# You *must* install grub, otherwise some of the bootloader mod files will silently be excluded from your ISO...
# ... and QEMU will give you CD ROM Code 0004 or 0009.
# This writes the grub binaries /usr/local/bin and requires root.
sudo make install

# Now you can make run-qemu from your host if you'd like!
```