### PR TITLE
VFS layer

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -6,7 +6,6 @@
 #![feature(non_null_convenience)]
 #![feature(offset_of)]
 #![feature(slice_ptr_get)]
-#![feature(error_in_core)] // stabilized in 1.81.0
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(not(test), no_main)]
 #![feature(negative_impls)]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -6,6 +6,7 @@
 #![feature(non_null_convenience)]
 #![feature(offset_of)]
 #![feature(slice_ptr_get)]
+#![feature(error_in_core)] // stabilized in 1.81.0
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(not(test), no_main)]
 #![feature(negative_impls)]
@@ -19,6 +20,7 @@ mod sync;
 mod threading;
 mod timer;
 mod user_program;
+pub mod vfs;
 
 extern crate alloc;
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -146,7 +146,7 @@ impl<'a> Iterator for DirIterator<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DirEntries {
     /// Raw directory entries, with names pointing to [`Self::filenames`]
     pub entries: Vec<RawDirEntry>,
@@ -155,9 +155,24 @@ pub struct DirEntries {
 }
 
 impl DirEntries {
+    /// Create a new empty list of directory entries.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Get filename associated with name ID, from [`RawDirEntry::name`].
     pub fn get_filename(&self, name: usize) -> &str {
         let s = &self.filenames[name..];
         &s[..s.find('\0').unwrap_or(s.len())]
+    }
+    pub fn add(&mut self, inode: INodeNum, r#type: INodeType, name: &str) {
+        let name_id = self.filenames.len();
+        self.filenames.push_str(name);
+        self.filenames.push('\0');
+        self.entries.push(RawDirEntry {
+            inode,
+            r#type,
+            name: name_id,
+        });
     }
     #[cfg(test)]
     /// Collect directory entries into a Vec, sorted by name.

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -37,6 +37,8 @@ pub enum Error {
     Unsupported,
     /// Write operation to a read-only file system
     ReadOnlyFS,
+    /// Process has too many open file descriptors
+    TooManyOpenFiles,
     /// Error accessing underlying storage device
     IO(String),
 }
@@ -59,6 +61,7 @@ impl core::fmt::Display for Error {
             Self::Exists => write!(f, "destination already exists"),
             Self::Unsupported => write!(f, "unsupported operation"),
             Self::ReadOnlyFS => write!(f, "read-only file system"),
+            Self::TooManyOpenFiles => write!(f, "too many open files"),
             Self::IO(s) => write!(f, "I/O error: {s}"),
         }
     }

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -11,7 +11,6 @@ pub type Path = str;
 /// when it closes its last open file to an inode. Otherwise,
 /// the filesystem will have to keep around the file's data indefinitely!
 #[derive(Debug, Clone, Copy)]
-#[must_use]
 pub struct FileHandle {
     /// inode number of this file
     pub inode: INodeNum,
@@ -128,8 +127,8 @@ pub trait FileSystem {
     /// Indicate that there are no more references to an open file/symlink/directory.
     ///
     /// If there are no links left to the file, the filesystem can delete it at this point.
-    /// The kernel must not use this or any other file handle pointing to the same file after calling this.
-    fn release(&mut self, file: FileHandle);
+    /// The kernel must not use any file handle pointing to this inode after calling this.
+    fn release(&mut self, inode: INodeNum);
     /// Read from file into buf at offset.
     ///
     /// The kernel must ensure that `file` is a regular file before calling this.

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -111,7 +111,7 @@ impl DirEntry<'_> {
     }
 }
 
-pub trait DirectoryIterator<'a>: Sized {
+pub trait DirectoryIterator: Sized {
     /// Get next file.
     ///
     /// Returns `Ok(None)` if the end of the directory was reached.
@@ -160,7 +160,7 @@ pub trait FileSystem {
     /// If entries are added/removed from the directory in between the call to [`DirectoryIterator::offset`]
     /// and this call, they may or may not be listed. But modifications to the directory must not
     /// cause directory entries to be repeated or unmodified entries to be skipped.
-    fn readdir(&self, dir: FileHandle, offset: u64) -> impl DirectoryIterator<'_>;
+    fn readdir(&self, dir: FileHandle, offset: u64) -> impl '_ + DirectoryIterator;
     /// Indicate that there are no more references to an inode
     /// (i.e. all file descriptors pointing to it have been closed).
     ///

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -66,6 +66,7 @@ pub struct FileInfo {
     pub nlink: u16,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum INodeType {
     /// Regular file
     File,

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -35,6 +35,8 @@ pub enum Error {
     Exists,
     /// Unsupported operation (e.g. file system does not support symlinks)
     Unsupported,
+    /// Write operation to a read-only file system
+    ReadOnlyFS,
     /// Error accessing underlying storage device
     IO(String),
 }
@@ -56,6 +58,7 @@ impl core::fmt::Display for Error {
             Self::NotEmpty => write!(f, "directory not empty"),
             Self::Exists => write!(f, "destination already exists"),
             Self::Unsupported => write!(f, "unsupported operation"),
+            Self::ReadOnlyFS => write!(f, "read-only file system"),
             Self::IO(s) => write!(f, "I/O error: {s}"),
         }
     }

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1,0 +1,172 @@
+pub mod tempfs;
+
+use core::num::NonZeroUsize;
+
+pub type INodeNum = u64;
+pub type Path = str;
+
+/// Represents an open file
+///
+/// **IMPORTANT**: the kernel must call [`FileSystem::release`]
+/// when it closes its last open file to an inode. Otherwise,
+/// the filesystem will have to keep around the file's data indefinitely!
+#[derive(Debug, Clone, Copy)]
+#[must_use]
+pub struct FileHandle {
+    /// inode number of this file
+    pub inode: INodeNum,
+    /// allows filesystem to store its own metadata about open files
+    pub fs_data: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    /// directory entry not found
+    NotFound,
+    /// operation expecting directory called with something that isn't a directory
+    NotDirectory,
+    /// operation expecting file called with a directory
+    IsDirectory,
+    /// no space left on device
+    NoSpace,
+    /// Too many hard links to file
+    TooManyLinks,
+    /// Called rmdir on non-empty directory
+    NotEmpty,
+    /// Target destination already exists
+    Exists,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "not found"),
+            Self::NotDirectory => write!(f, "not a directory"),
+            Self::IsDirectory => write!(f, "is a directory"),
+            Self::NoSpace => write!(f, "no space left on device"),
+            Self::TooManyLinks => write!(f, "too many hard links to file"),
+            Self::NotEmpty => write!(f, "directory not empty"),
+            Self::Exists => write!(f, "destination already exists"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// File or directory information, as returned by stat.
+pub struct FileInfo {
+    /// Whether this is a file, directory, etc.
+    pub r#type: INodeType,
+    /// inode number
+    pub inode: INodeNum,
+    /// Size in bytes
+    pub size: u64,
+    /// Number of hard links
+    pub nlink: u16,
+}
+
+pub enum INodeType {
+    /// Regular file
+    File,
+    /// Symbolic link
+    Link,
+    /// Directory
+    Directory,
+}
+
+/// Directory entry information
+pub struct DirEntry<'a> {
+    /// Type of entry
+    pub r#type: INodeType,
+    /// inode number
+    pub inode: INodeNum,
+    /// Name of entry
+    pub name: &'a Path,
+}
+
+pub trait DirectoryIterator<'a>: Sized {
+    /// Get next file.
+    ///
+    /// Returns `Ok(None)` if the end of the directory was reached.
+    fn next(&mut self) -> Result<Option<DirEntry<'_>>>;
+}
+
+pub trait FileSystem {
+    type DirectoryIterator<'a>: DirectoryIterator<'a>
+    where
+        Self: 'a;
+    /// Get root inode number
+    fn root(&self) -> INodeNum;
+    /// Look up directory entry
+    fn lookup(&self, parent: FileHandle, name: &Path) -> Result<INodeNum>;
+    /// Open an existing file/directory/symlink.
+    fn open(&mut self, inode: INodeNum) -> Result<FileHandle>;
+    /// Create a new file in parent, or open it if it already exists (without truncating).
+    ///
+    /// The kernel must ensure that `parent` is a directory and that `name` is non-empty.
+    fn create(&mut self, parent: FileHandle, name: &Path) -> Result<FileHandle>;
+    /// Make directory in parent
+    ///
+    /// The kernel must ensure that `parent` is a directory and that `name` is non-empty.
+    /// If `name` already exists (whether as a directory or as a file), [`Error::Exists`] should be returned.
+    fn mkdir(&mut self, parent: FileHandle, name: &Path) -> Result<()>;
+    /// Remove a (link to a) file/symlink in parent
+    ///
+    /// The kernel must ensure that `parent` is a directory and that `name` is non-empty.
+    /// The filesystem must keep around the file in memory or on disk until [`Self::release`] is called.
+    fn unlink(&mut self, parent: FileHandle, name: &Path) -> Result<()>;
+    /// Remove a directory in parent
+    ///
+    /// The kernel must ensure that `parent` is a directory before calling this.
+    fn rmdir(&mut self, parent: FileHandle, name: &Path) -> Result<()>;
+    /// read entries in a directory
+    ///
+    /// The kernel must ensure that `dir` is a directory before calling this.
+    fn readdir(&self, dir: FileHandle) -> Self::DirectoryIterator<'_>;
+    /// Indicate that there are no more references to an open file/symlink/directory.
+    ///
+    /// If there are no links left to the file, the filesystem can delete it at this point.
+    /// The kernel must not use this or any other file handle pointing to the same file after calling this.
+    fn release(&mut self, file: FileHandle);
+    /// Read from file into buf at offset.
+    ///
+    /// The kernel must ensure that `file` is a regular file before calling this.
+    fn read(&self, file: FileHandle, offset: u64, buf: &mut [u8]) -> Result<usize>;
+    /// Write to file from buf at offset.
+    ///
+    /// The kernel must ensure that `file` is a regular file before calling this.
+    fn write(&mut self, file: FileHandle, offset: u64, buf: &[u8]) -> Result<usize>;
+    /// Get information about an open file/symlink/directory.
+    fn stat(&self, file: FileHandle) -> Result<FileInfo>;
+    /// Create a hard link
+    ///
+    /// As on Linux, this should return [`Error::Exists`] and do nothing if the destination already exists.
+    ///
+    /// The kernel must ensure that parent is a directory, and that `name` is non-empty.
+    fn link(&mut self, source: FileHandle, parent: FileHandle, name: &Path) -> Result<()>;
+    /// Create a symbolic link
+    ///
+    /// As on Linux, this should return [`Error::Exists`] and do nothing if the destination already exists.
+    ///
+    /// The kernel must ensure that parent is a directory, and that `link` and `name` are non-empty.
+    fn symlink(&mut self, link: &Path, parent: FileHandle, name: &Path) -> Result<()>;
+    /// Read a symbolic link
+    ///
+    /// Returns the number of bytes filled into `buf`, or `Ok(None)` if `buf`
+    /// is too short (in which case the contents of `buf` are unspecified).
+    ///
+    /// Note that you can get the size of buffer needed from calling [`FileInfo::size`]
+    /// on the return value of [`Self::stat`], but this may still fail if the
+    /// link is modified between the calls to stat and readlink.
+    fn readlink(&self, link: FileHandle, buf: &mut Path) -> Result<Option<NonZeroUsize>>;
+    /// Set a new file size.
+    ///
+    /// If this is less than the previous size, the extra data is lost.
+    /// If it's larger than the previous size, the extended part should be filled with
+    /// null bytes.
+    ///
+    /// The kernel must ensure that `file` is a regular file before calling this.
+    fn truncate(&mut self, file: FileHandle, size: u64) -> Result<()>;
+}

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -194,7 +194,7 @@ pub trait FileSystem {
     /// Returns the prefix of `buf` which has been filled with the desintation, or `Ok(None)` if `buf`
     /// is too short (in which case the contents of `buf` are unspecified).
     ///
-    /// Note that you can get the size of buffer needed from calling [`FileInfo::size`]
+    /// Note that you can get the size of buffer needed by accessing [`FileInfo::size`]
     /// on the return value of [`Self::stat`].
     fn readlink<'a>(&self, link: FileHandle, buf: &'a mut Path) -> Result<Option<&'a str>>;
     /// Set a new file size.

--- a/kernel/src/vfs/read_only_test.rs
+++ b/kernel/src/vfs/read_only_test.rs
@@ -1,0 +1,86 @@
+use crate::vfs::{FileSystem, INodeNum, INodeType, OwnedDirEntry};
+use std::io::prelude::*;
+
+type StdPath = std::path::Path;
+type StdPathBuf = std::path::PathBuf;
+
+fn read_only_test_on<F: FileSystem>(fs: &mut F, fs_dir_inode: INodeNum, host_directory: &StdPath) {
+    // compare directory entries
+    let mut dir_handle = fs.open(fs_dir_inode).unwrap();
+    let fs_dir_ents = fs.readdir(&mut dir_handle).unwrap().to_sorted_vec();
+    let mut host_dir_ents: Vec<OwnedDirEntry> = std::fs::read_dir(host_directory)
+        .unwrap()
+        .filter_map(|std_dirent| {
+            let std_dirent = std_dirent.unwrap();
+            let name = std_dirent
+                .file_name()
+                .to_str()
+                .expect("bad UTF-8 in host filename")
+                .to_owned();
+            if name == "." || name == ".." {
+                return None;
+            }
+            let file_type = std_dirent.file_type().unwrap();
+            let r#type = if file_type.is_symlink() {
+                INodeType::Link
+            } else if file_type.is_dir() {
+                INodeType::Directory
+            } else if file_type.is_file() {
+                INodeType::File
+            } else {
+                panic!("Weird file type in host directory: {file_type:?}");
+            };
+            Some(OwnedDirEntry {
+                inode: 0,
+                name: name.into(),
+                r#type,
+            })
+        })
+        .collect();
+    host_dir_ents.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(host_dir_ents.len(), fs_dir_ents.len());
+    for (host_ent, fs_ent) in host_dir_ents.iter().zip(fs_dir_ents.iter()) {
+        let mut host_subpath = StdPathBuf::from(host_directory);
+        host_subpath.push(host_ent.name.as_ref());
+        assert_eq!(host_ent.name, fs_ent.name);
+        assert_eq!(host_ent.r#type, fs_ent.r#type);
+        match fs_ent.r#type {
+            INodeType::Directory => {
+                read_only_test_on(fs, fs_ent.inode, &host_subpath);
+            }
+            INodeType::File => {
+                let mut file = fs.open(fs_ent.inode).unwrap();
+                // weird buffer size to try to catch edge cases (e.g. read crossing sector)
+                let mut buffer = [0u8; 37];
+                let mut fs_contents = vec![];
+                loop {
+                    let n = fs
+                        .read(&mut file, fs_contents.len() as u64, &mut buffer)
+                        .unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    fs_contents.extend_from_slice(&buffer[..n]);
+                }
+                let mut host_contents = vec![];
+                std::fs::File::open(&host_subpath)
+                    .unwrap()
+                    .read_to_end(&mut host_contents)
+                    .unwrap();
+                assert_eq!(
+                    host_contents,
+                    fs_contents,
+                    "mismatch at file {}",
+                    host_subpath.to_string_lossy()
+                );
+            }
+            INodeType::Link => todo!(),
+        }
+    }
+}
+
+/// ensure the filesystem matches the given directory on disk
+pub fn read_only_test<F: FileSystem>(fs: &mut F, host_directory: impl AsRef<StdPath>) {
+    let root = fs.root();
+    read_only_test_on(fs, root, host_directory.as_ref());
+}

--- a/kernel/src/vfs/tempfs.rs
+++ b/kernel/src/vfs/tempfs.rs
@@ -1,0 +1,579 @@
+#[cfg(not(test))]
+use crate::println;
+#[cfg(test)]
+use std::println;
+
+use crate::vfs::{
+    DirEntry, DirectoryIterator, Error, FileHandle, FileInfo, FileSystem, INodeNum, INodeType,
+    Path, Result,
+};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use core::{cmp::min, mem::size_of, num::NonZeroUsize};
+
+struct TempFile {
+    nlink: u16,
+    data: Vec<u8>,
+}
+
+struct TempDirectory {
+    entries: BTreeMap<String, INodeNum>,
+    nlink: u16,
+}
+
+struct TempLink {
+    path: String,
+    nlink: u16,
+}
+
+enum TempINode {
+    File(TempFile),
+    Directory(TempDirectory),
+    Link(TempLink),
+}
+
+/// in-memory filesystem
+pub struct TempFs {
+    inodes: BTreeMap<INodeNum, TempINode>,
+}
+
+const ROOT_INO: INodeNum = 1;
+
+pub struct TempDirectoryIterator<'a> {
+    fs: &'a TempFs,
+    it: alloc::collections::btree_map::Iter<'a, String, INodeNum>,
+    filename: String,
+}
+
+impl<'a> DirectoryIterator<'a> for TempDirectoryIterator<'a> {
+    fn next(&mut self) -> Result<Option<DirEntry>> {
+        let Some((name, inode_num)) = self.it.next() else {
+            return Ok(None);
+        };
+        let inode_num = *inode_num;
+        let inode = self
+            .fs
+            .inodes
+            .get(&inode_num)
+            .expect("tempfs consistency error — reference to nonexistent inode");
+        self.filename = name.into();
+        let r#type = match inode {
+            TempINode::File(_) => INodeType::File,
+            TempINode::Directory(_) => INodeType::Directory,
+            TempINode::Link(_) => INodeType::Link,
+        };
+        Ok(Some(DirEntry {
+            inode: inode_num,
+            r#type,
+            name: &self.filename,
+        }))
+    }
+}
+
+impl Default for TempFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const NO_INODE: &str = "Couldn't find inode — either kernel is using filesystem incorrectly or we freed an inode when we shouldn't have.";
+impl TempFs {
+    pub fn new() -> TempFs {
+        let root = TempINode::Directory(TempDirectory {
+            entries: BTreeMap::new(),
+            nlink: 1,
+        });
+        let mut inodes = BTreeMap::new();
+        inodes.insert(ROOT_INO, root);
+        TempFs { inodes }
+    }
+    fn get_inode(&self, handle: FileHandle) -> &TempINode {
+        self.inodes.get(&handle.inode).expect(NO_INODE)
+    }
+    fn get_inode_mut(&mut self, handle: FileHandle) -> &mut TempINode {
+        self.inodes.get_mut(&handle.inode).expect(NO_INODE)
+    }
+    fn add_inode(&mut self, inode: TempINode) -> INodeNum {
+        // Since inodes are stored in a BTreeMap, the last entry is the maximum inode value.
+        // So we take one more than that. This isn't realistically going to overflow a u64.
+        if size_of::<INodeNum>() < 8 {
+            panic!(
+                "this function should be updated to handle smaller inode size (u32 could overflow)"
+            );
+        }
+        let inode_num = *self
+            .inodes
+            .last_entry()
+            .expect("filesystem should at least contain root")
+            .key()
+            + 1;
+        self.inodes.insert(inode_num, inode);
+        inode_num
+    }
+    // performs either unlink or rmdir.
+    fn unlink_or_rmdir(&mut self, parent: FileHandle, name: &Path, is_rmdir: bool) -> Result<()> {
+        let parent_inode = self.get_inode(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Kernel should call stat to make sure this is a directory before removing something from it.");
+        };
+        let inode_num = *parent_dir.entries.get(name).ok_or(Error::NotFound)?;
+        let inode = self
+            .inodes
+            .get_mut(&inode_num)
+            .expect("inconsistent filesystem state — referenced inode doesn't exist");
+        // Note that we don't actually remove the inode from inodes here;
+        // we do that in `release`, so that existing file handles can still access
+        // the file until then.
+        match inode {
+            TempINode::Directory(d) => {
+                if !is_rmdir {
+                    return Err(Error::NotDirectory);
+                }
+                if !d.entries.is_empty() {
+                    return Err(Error::NotEmpty);
+                }
+                assert!(
+                    d.nlink > 0,
+                    "VFS rmdir called on an already-deleted directory"
+                );
+                d.nlink -= 1;
+            }
+            TempINode::File(f) => {
+                if is_rmdir {
+                    return Err(Error::NotDirectory);
+                }
+                assert!(f.nlink > 0, "VFS unlink called on file with 0 links");
+                f.nlink -= 1;
+            }
+            TempINode::Link(l) => {
+                if is_rmdir {
+                    return Err(Error::NotDirectory);
+                }
+                assert!(
+                    l.nlink > 0,
+                    "VFS unlink called on an already-deleted symlink"
+                );
+                l.nlink -= 1;
+            }
+        }
+        let parent_inode = self.get_inode_mut(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("This should never happen due to check above.");
+        };
+        parent_dir.entries.remove(name);
+        Ok(())
+    }
+}
+
+const DEBUG_TEMPFS: bool = true;
+
+impl FileSystem for TempFs {
+    type DirectoryIterator<'a> = TempDirectoryIterator<'a>;
+    fn root(&self) -> INodeNum {
+        ROOT_INO
+    }
+    fn lookup(&self, parent: FileHandle, name: &Path) -> Result<INodeNum> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: lookup in {}: {}", parent.inode, name);
+        }
+        let parent_inode = self.get_inode(parent);
+        let TempINode::Directory(dir) = parent_inode else {
+            return Err(Error::NotDirectory);
+        };
+        dir.entries.get(name).ok_or(Error::NotFound).copied()
+    }
+    fn open(&mut self, inode: INodeNum) -> Result<FileHandle> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: open {}", inode);
+        }
+        if self.inodes.get(&inode).is_none() {
+            return Err(Error::NotFound);
+        }
+        Ok(FileHandle { inode, fs_data: 0 })
+    }
+    fn create(&mut self, parent: FileHandle, name: &Path) -> Result<FileHandle> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: create in {}: {}", parent.inode, name);
+        }
+        if name.is_empty() {
+            panic!("Empty name passed to create");
+        }
+        // first check if file already exists
+        let parent_inode = self.get_inode_mut(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Kernel should call stat to make sure this is a directory before creating a file in it.");
+        };
+        let inode_num = parent_dir.entries.get(name).copied().unwrap_or_else(|| {
+            // create new file
+            let inode = TempINode::File(TempFile {
+                nlink: 1,
+                data: Vec::new(),
+            });
+            let inode_num = self.add_inode(inode);
+            let parent_inode = self.get_inode_mut(parent);
+            let TempINode::Directory(parent_dir) = parent_inode else {
+                panic!("should never happen due to check above");
+            };
+            parent_dir.entries.insert(name.into(), inode_num);
+            inode_num
+        });
+        Ok(FileHandle {
+            inode: inode_num,
+            fs_data: 0,
+        })
+    }
+    fn unlink(&mut self, parent: FileHandle, name: &Path) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: unlink in {}: {}", parent.inode, name);
+        }
+        if name.is_empty() {
+            panic!("Empty name passed to unlink");
+        }
+        self.unlink_or_rmdir(parent, name, false)
+    }
+    fn rmdir(&mut self, parent: FileHandle, name: &Path) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: rmdir in {}: {}", parent.inode, name);
+        }
+        if name.is_empty() {
+            panic!("Empty name passed to rmdir");
+        }
+        self.unlink_or_rmdir(parent, name, true)
+    }
+    fn readdir(&self, dir: FileHandle) -> TempDirectoryIterator<'_> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: readdir {}", dir.inode);
+        }
+        let inode = self.get_inode(dir);
+        let TempINode::Directory(dir) = inode else {
+            panic!("Kernel should call stat to make sure this is a directory before calling readdir on it.");
+        };
+        TempDirectoryIterator {
+            fs: self,
+            it: dir.entries.iter(),
+            filename: String::new(),
+        }
+    }
+    fn release(&mut self, file: FileHandle) {
+        if DEBUG_TEMPFS {
+            println!("tempfs: release {}", file.inode);
+        }
+        let inode = self.get_inode(file);
+        let should_delete = match inode {
+            TempINode::Link(_) | TempINode::Directory(_) => true,
+            TempINode::File(f) => f.nlink == 0,
+        };
+        if should_delete {
+            // we can safely remove the inode.
+            self.inodes.remove(&file.inode);
+        }
+    }
+    fn read(&self, file: FileHandle, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        if DEBUG_TEMPFS {
+            println!(
+                "tempfs: read from {} @ offset {} length {}",
+                file.inode,
+                offset,
+                buf.len()
+            );
+        }
+        let inode = self.get_inode(file);
+        let TempINode::File(f) = inode else {
+            panic!("Kernel should make sure this is a regular file before reading from it.");
+        };
+        if offset >= f.data.len() as u64 {
+            // can't read any data
+            return Ok(0);
+        }
+        let offset = offset as usize; // fits into usize by check above
+        let read_len = min(buf.len(), f.data.len() - offset);
+        buf[..read_len].copy_from_slice(&f.data[offset..offset + read_len]);
+        Ok(read_len)
+    }
+    fn write(&mut self, file: FileHandle, offset: u64, buf: &[u8]) -> Result<usize> {
+        if DEBUG_TEMPFS {
+            println!(
+                "tempfs: write to {} @ offset {} length {}",
+                file.inode,
+                offset,
+                buf.len()
+            );
+        }
+        let inode = self.get_inode_mut(file);
+        let TempINode::File(f) = inode else {
+            panic!("Kernel should make sure this is a regular file before writing to it.");
+        };
+        if offset > (isize::MAX as u64).saturating_sub(buf.len() as u64) {
+            // file data would exceed isize::MAX bytes
+            return Err(Error::NoSpace);
+        }
+        let offset = offset as usize;
+        // amount we need to grow the file by
+        let grow_amount = (offset + buf.len()).saturating_sub(f.data.len());
+        // return no space error if allocation failed
+        f.data
+            .try_reserve(grow_amount)
+            .map_err(|_| Error::NoSpace)?;
+        for _ in 0..grow_amount {
+            // NOTE: files with holes will not perform well.
+            f.data.push(0);
+        }
+        f.data[offset..offset + buf.len()].copy_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn stat(&self, file: FileHandle) -> Result<FileInfo> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: stat {}", file.inode);
+        }
+        let inode = self.get_inode(file);
+        match inode {
+            TempINode::Directory(d) => Ok(FileInfo {
+                r#type: INodeType::Directory,
+                inode: file.inode,
+                nlink: 1,
+                // pretend that each entry takes up 1 byte (this doesn't matter much)
+                size: d.entries.len() as u64,
+            }),
+            TempINode::File(f) => Ok(FileInfo {
+                r#type: INodeType::File,
+                inode: file.inode,
+                nlink: f.nlink,
+                size: f.data.len() as u64,
+            }),
+            TempINode::Link(l) => Ok(FileInfo {
+                r#type: INodeType::Link,
+                inode: file.inode,
+                nlink: 1,
+                size: l.path.len() as u64,
+            }),
+        }
+    }
+    fn link(&mut self, source: FileHandle, parent: FileHandle, name: &Path) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!(
+                "tempfs: create link to {} in {}: {}",
+                source.inode, parent.inode, name
+            );
+        }
+        // check for existence
+        let parent_inode = self.get_inode(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Kernel should make sure parent is a directory before creating a link in it.");
+        };
+        if parent_dir.entries.contains_key(name) {
+            return Err(Error::Exists);
+        }
+        // increment link count
+        let source_inode = self.get_inode_mut(source);
+        let TempINode::File(f) = source_inode else {
+            // currently don't support hard-linking symlinks/directories
+            // (would be easy to fix)
+            return Err(Error::TooManyLinks);
+        };
+        f.nlink = f.nlink.checked_add(1).ok_or(Error::TooManyLinks)?;
+        // insert directory entry
+        // we can't just reuse parent_inode from above, since we accessed self in between.
+        let parent_inode = self.get_inode_mut(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Should never happen since we did this check above.");
+        };
+        parent_dir.entries.insert(name.into(), source.inode);
+        Ok(())
+    }
+    fn symlink(&mut self, link: &Path, parent: FileHandle, name: &Path) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!(
+                "tempfs: create symlink to {} in {}: {}",
+                link, parent.inode, name
+            );
+        }
+        // check for existence
+        let parent_inode = self.get_inode(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Kernel should make sure parent is a directory before creating a link in it.");
+        };
+        if name.is_empty() || link.is_empty() {
+            panic!("Empty path passed to symlink.");
+        }
+        if parent_dir.entries.contains_key(name) {
+            return Err(Error::Exists);
+        }
+        let link_inode = TempINode::Link(TempLink {
+            path: link.into(),
+            nlink: 1,
+        });
+        let link_inode_num = self.add_inode(link_inode);
+        // we can't just reuse parent_inode from above, since we accessed self in between.
+        let parent_inode = self.get_inode_mut(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("Should never happen since we did this check above.");
+        };
+        parent_dir.entries.insert(name.into(), link_inode_num);
+        Ok(())
+    }
+    fn readlink(&self, link: FileHandle, buf: &mut Path) -> Result<Option<NonZeroUsize>> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: readlink {} (buf len = {})", link.inode, buf.len());
+        }
+        let inode = self.get_inode(link);
+        let TempINode::Link(link) = inode else {
+            panic!(
+                "Kernel should use stat to make sure this is a link before calling readlink on it."
+            );
+        };
+        if buf.len() < link.path.len() {
+            return Ok(None);
+        }
+        // unfortunately, unsafe code is currently the only way to write to a &mut str
+        // SAFETY: we ensure that bytes is valid UTF-8 after this call,
+        //         since link.path must be valid UTF-8.
+        let bytes = unsafe { buf.as_bytes_mut() };
+        bytes[..link.path.len()].copy_from_slice(link.path.as_bytes());
+        for byte in &mut bytes[link.path.len()..] {
+            if (*byte >> 6) == 0b10 {
+                // replace continuation bytes following link.path with zeroes,
+                // to ensure bytes remains valid UTF-8.
+                *byte = 0;
+            } else {
+                break;
+            }
+        }
+        Ok(Some(
+            NonZeroUsize::new(link.path.len()).expect("symlink should have non-empty path"),
+        ))
+    }
+    fn truncate(&mut self, file: FileHandle, size: u64) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: truncate {} to {} bytes", file.inode, size);
+        }
+        let inode = self.get_inode_mut(file);
+        let TempINode::File(file) = inode else {
+            panic!(
+                "Kernel should use stat to make sure this is a file before calling truncate on it."
+            );
+        };
+        if size <= file.data.len() as u64 {
+            // shrink file
+            file.data.truncate(size as usize);
+        } else {
+            // grow file
+            let size: usize = size.try_into().map_err(|_| Error::NoSpace)?;
+            let grow_by = size - file.data.len();
+            file.data.try_reserve(grow_by).map_err(|_| Error::NoSpace)?;
+            for _ in 0..grow_by {
+                file.data.push(0);
+            }
+        }
+        Ok(())
+    }
+    fn mkdir(&mut self, parent: FileHandle, name: &Path) -> Result<()> {
+        if DEBUG_TEMPFS {
+            println!("tempfs: mkdir in {}: {}", parent.inode, name);
+        }
+        if name.is_empty() {
+            panic!("mkdir called with empty name");
+        }
+        let parent_inode = self.get_inode(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!(
+                "Kernel should make sure parent is a directory before making a directory in it."
+            );
+        };
+        if parent_dir.entries.contains_key(name) {
+            return Err(Error::Exists);
+        }
+        let inode = TempINode::Directory(TempDirectory {
+            entries: BTreeMap::new(),
+            nlink: 1,
+        });
+        let inode_num = self.add_inode(inode);
+        let parent_inode = self.get_inode_mut(parent);
+        let TempINode::Directory(parent_dir) = parent_inode else {
+            panic!("This should never happen due to the check above");
+        };
+        parent_dir.entries.insert(name.into(), inode_num);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Action {
+        Open,
+        Create,
+        Mkdir,
+    }
+    // open/create/mkdir an absolute path
+    fn get_path<F: FileSystem>(
+        fs: &mut F,
+        path: &Path,
+        action: Action,
+    ) -> Result<Option<FileHandle>> {
+        if !path.starts_with("/") {
+            panic!("not an absolute path");
+        }
+        let mut file = fs.open(fs.root())?;
+        let component_count = path.split('/').count();
+        for (i, item) in path.split('/').enumerate() {
+            if item.is_empty() {
+                continue;
+            }
+            let next_file = if action == Action::Create && i == component_count - 1 {
+                return Ok(Some(fs.create(file, item)?));
+            } else if action == Action::Mkdir && i == component_count - 1 {
+                fs.mkdir(file, item)?;
+                return Ok(None);
+            } else {
+                fs.open(fs.lookup(file, item)?)?
+            };
+            file = next_file;
+        }
+        Ok(Some(file))
+    }
+    // mkdir an absolute path
+    fn mkdir_path<F: FileSystem>(fs: &mut F, path: &Path) -> Result<()> {
+        get_path(fs, path, Action::Mkdir)?;
+        Ok(())
+    }
+    // create an absolute path
+    fn create_path<F: FileSystem>(fs: &mut F, path: &Path) -> Result<FileHandle> {
+        Ok(get_path(fs, path, Action::Create)?.unwrap())
+    }
+    // open an absolute path
+    fn open_path<F: FileSystem>(fs: &mut F, path: &Path) -> Result<FileHandle> {
+        Ok(get_path(fs, path, Action::Open)?.unwrap())
+    }
+    #[test]
+    // one regular file in root
+    fn simple_write_read() {
+        let mut fs = TempFs::new();
+        let test = create_path(&mut fs, "/test").unwrap();
+        assert_eq!(fs.write(test, 0, b"hello").unwrap(), 5);
+        fs.release(test); // this should do nothing since there is still a link to /test
+        let test = open_path(&mut fs, "/test").unwrap();
+        let mut buf = [0; 6];
+        assert_eq!(fs.read(test, 0, &mut buf[..]).unwrap(), 5);
+        assert_eq!(&buf[..], b"hello\0");
+        buf.fill(0);
+        for i in 0..buf.len() {
+            assert_eq!(
+                fs.read(test, i as u64, &mut buf[i..i + 1]).unwrap(),
+                if i < 5 { 1 } else { 0 }
+            );
+        }
+        assert_eq!(&buf[..], b"hello\0");
+        fs.release(test); // this should do nothing since there is still a link to /test
+    }
+    #[test]
+    // test directories
+    fn dirs() {
+        let mut fs = TempFs::new();
+        mkdir_path(&mut fs, "/dir1").unwrap();
+        mkdir_path(&mut fs, "/dir2").unwrap();
+        let foo = create_path(&mut fs, "/dir1/foo").unwrap();
+        let bar = create_path(&mut fs, "/dir2/bar").unwrap();
+        assert_eq!(fs.write(foo, 0, b"foo").unwrap(), 3);
+        assert_eq!(fs.write(bar, 0, b"bar").unwrap(), 3);
+    }
+}

--- a/kernel/src/vfs/tempfs.rs
+++ b/kernel/src/vfs/tempfs.rs
@@ -107,7 +107,7 @@ pub struct TempDirectoryIterator<'a> {
     offset: u64,
 }
 
-impl<'a> DirectoryIterator<'a> for TempDirectoryIterator<'a> {
+impl<'a> DirectoryIterator for TempDirectoryIterator<'a> {
     fn next(&mut self) -> Result<Option<DirEntry>> {
         let Some((id, (inode_num, name))) = self.it.next() else {
             return Ok(None);
@@ -295,7 +295,7 @@ impl FileSystem for TempFs {
         }
         self.unlink_or_rmdir(parent, name, true)
     }
-    fn readdir(&self, dir: FileHandle, offset: u64) -> impl DirectoryIterator<'_> {
+    fn readdir(&self, dir: FileHandle, offset: u64) -> impl '_ + DirectoryIterator {
         if DEBUG_TEMPFS {
             println!("tempfs: readdir {}", dir.inode);
         }


### PR DESCRIPTION
Here is an initial version of the VFS layer, together with a "reference implementation" of an in-memory filesystem. The key thing here is the `FileSystem` trait which we can implement for each supported filesystem.  I've tried to follow the FUSE API quite closely, with some simplifications. Let me know what you think!

- Right now there is no mode/owner/group for files. I'm not sure whether we're planning on having multi-user support, but it shouldn't be too hard to add this if we are.
- Also, access/create/modify times can be added in the future.
- ~~It's quite difficult to handle the `offset` argument to `readdir` correctly (in fact, most FUSE filesystems I found online just ignore it), i.e. in such a way that unrelated files are never repeated/skipped if a directory is modified between calls. But I'm not sure if there's a better alternative, assuming we want a POSIX `readdir`-like userspace API (one option is to remove `offset` and just read all the entries into memory in the kernel whenever a directory is opened).~~ (readdir now works in a different way that avoids this issue — we will just read all directory entries into memory whenever a directory is opened; it's probably more efficient to do that anyways)
- Right now filenames are required to be valid UTF-8, which isn't required on Linux. I think this is a good idea in theory, but if we want to be entirely compatible with existing filesystems, we could change this.
 