### PR TITLE
Proposal: Fixing internal inconsistency detected in kernel allocator with ptr 0x8148C000

### DIFF
--- a/shared/src/paging.rs
+++ b/shared/src/paging.rs
@@ -432,7 +432,12 @@ impl<A: Allocator> Drop for PageManager<A> {
             let Some(page_table_addr) = NonNull::new(page_table_addr as *mut u8) else {
                 panic!("present page directory entry contained null page table address");
             };
-            unsafe { self.alloc.deallocate(page_table_addr, PAGE_TABLE_LAYOUT) };
+
+            // Huge Pages are not allocated with an allocator.
+            // Seems like we might not need to free them.
+            if !pde.page_size() {
+                unsafe { self.alloc.deallocate(page_table_addr, PAGE_TABLE_LAYOUT) };
+            }
         }
 
         unsafe {


### PR DESCRIPTION
**Problem**: On startup, we panic when we're cleaning up our `PageManager` struct. Stack trace is below. This happens because we free a pointer (constructed via a table frame number in our page directory) that was not allocated via our block allocator (so `.deallocate` can't find a subblock allocator that works nicely with it).

This frame number was created via `huge_map`, which does not use the allocator (as opposed to `map`, which uses the allocator). The frame number for huge_maps I think points to the beginning of the 4MB section (instead of a page table), so it is not allocated (and does not need to be dealloc'd).

```
#0  kidneyos::mem::{impl#2}::dealloc (self=0x8016b008 <kidneyos::KERNEL_ALLOCATOR::h6a290f7483a3673f>, ptr=0x8148c000, layout=...) at kernel/src/mem/mod.rs:269
#1  0x80147df0 in kidneyos::_::__rust_dealloc (ptr=0x8148c000, size=4096, align=4096) at kernel/src/main.rs:27
#2  0x8013a69b in alloc::alloc::dealloc (ptr=0x8148c000, layout=...)
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/alloc.rs:117
#3  0x8013a6fe in alloc::alloc::{impl#1}::deallocate (self=0x8117d0ac, ptr=..., layout=...)
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/alloc.rs:254
#4  0x801406f8 in kidneyos_shared::paging::{impl#9}::drop<alloc::alloc::Global> (self=0x8117d0a4) at shared/src/paging.rs:439
#5  0x801400f0 in core::ptr::drop_in_place<kidneyos_shared::paging::PageManager<alloc::alloc::Global>> ()
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:507
#6  0x80140053 in core::ptr::drop_in_place<kidneyos::threading::thread_control_block::ThreadControlBlock> ()
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:507
#7  0x8013fc47 in core::ptr::drop_in_place<alloc::boxed::Box<kidneyos::threading::thread_control_block::ThreadControlBlock, alloc::alloc::Global>> ()
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:507
#8  0x801428b3 in core::mem::drop<alloc::boxed::Box<kidneyos::threading::thread_control_block::ThreadControlBlock, alloc::alloc::Global>> (_x=0x8117d088)
    at /Users/desgroup/.rustup/toolchains/nightly-2024-01-04-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:992
#9  0x80141eff in kidneyos::threading::context_switch::switch_threads (status_for_current_thread=kidneyos::threading::thread_control_block::ThreadStatus::Ready, 
    switch_to=0x8117d088) at kernel/src/threading/context_switch.rs:58
#10 0x8014256b in kidneyos::threading::scheduling::scheduler_yield (status_for_current_thread=kidneyos::threading::thread_control_block::ThreadStatus::Ready)
    at kernel/src/threading/scheduling/mod.rs:37
#11 0x801425d9 in kidneyos::threading::scheduling::scheduler_yield_and_continue () at kernel/src/threading/scheduling/mod.rs:46
#12 0x801422fa in kidneyos::threading::idle_function () at kernel/src/threading/mod.rs:74
#13 0x801422e2 in kidneyos::threading::thread_system_start (kernel_page_manager=..., init_elf=...) at kernel/src/threading/mod.rs:65
#14 0x80147d66 in kidneyos::main (mem_upper=3144576, video_memory_skip_lines=5) at kernel/src/main.rs:68
```

So, we can check to see if this is a large page before `dealloc`ating it.