### PR TITLE
Refactor interrupt-related code

### DIFF
--- a/kernel/src/interrupts/idt.rs
+++ b/kernel/src/interrupts/idt.rs
@@ -2,13 +2,13 @@
 // https://wiki.osdev.org/Interrupts_tutorial
 // https://wiki.osdev.org/Exceptions
 
-use crate::user_program::syscall;
 use arbitrary_int::{u2, u4};
 use bitbybit::bitfield;
 use core::{arch::asm, mem::size_of};
 
-use crate::threading::scheduling;
-use crate::timer;
+use crate::interrupts::intr_handler::{
+    page_fault_handler, syscall_handler, timer_interrupt_handler, unhandled_handler,
+};
 
 #[repr(align(8))]
 #[bitfield(u64, default = 0)]
@@ -39,82 +39,6 @@ static mut IDT: [GateDescriptor; IDT_LEN] = [GateDescriptor::DEFAULT; IDT_LEN];
 // horribly dangerous... The current behaviour is currently safe fine for cases
 // where we're entering a handler from usermode though, because when doing that
 // we get the new stack from the TSS.
-
-#[naked]
-unsafe extern "C" fn unhandled_handler() -> ! {
-    fn inner() -> ! {
-        panic!("unhandled interrupt");
-    }
-
-    asm!(
-        "call {}",
-        sym inner,
-        options(noreturn),
-    );
-}
-
-#[naked]
-unsafe extern "C" fn page_fault_handler() -> ! {
-    unsafe fn inner(error_code: u32, return_eip: usize) -> ! {
-        let vaddr: usize;
-        asm!("mov {}, cr2", out(reg) vaddr);
-        panic!("page fault with error code {error_code:#b} occurred when trying to access {vaddr:#X} from instruction at {return_eip:#X}");
-    }
-
-    asm!(
-        "call {}",
-        sym inner,
-        options(noreturn),
-    );
-}
-
-#[naked]
-unsafe extern "C" fn syscall_handler() -> ! {
-    asm!(
-        "
-        // Push arguments to stack.
-        push edx
-        push ecx
-        push ebx
-        push eax
-
-        // TODO: We need to define what our syscall ABI is allowed to clobber
-        // and what it must preserve, then actually do that. We should also
-        // investigate what actual OSs do to ensure that we're not leaking
-        // sensitive kernel data, even if we are respecting our ABI.
-
-        call {}
-        // eax will contain the handler's return value, which is where it should
-        // remain when we return to the program.
-
-        add esp, 16 // Drop arguments from stack.
-
-        iretd
-        ",
-        sym syscall::handler,
-        options(noreturn),
-    );
-}
-
-#[naked]
-unsafe extern "C" fn timer_interrupt_handler() -> ! {
-    asm!(
-        "
-        // Push IRQ0 value onto the stack.
-        push 0x0
-        call {} // Update system clock
-        call {} // Send EOI signal to PICs
-        call {} // Yield process
-
-        add esp, 4 // Drop arguments from stack
-        iretd
-        ",
-        sym timer::step_sys_clock,
-        sym timer::send_eoi,
-        sym scheduling::scheduler_yield_and_continue,
-        options(noreturn),
-    );
-}
 
 static mut IDT_DESCRIPTOR: IDTDescriptor = IDTDescriptor {
     size: size_of::<[GateDescriptor; IDT_LEN]>() as u16 - 1,

--- a/kernel/src/interrupts/idt.rs
+++ b/kernel/src/interrupts/idt.rs
@@ -48,7 +48,7 @@ static mut IDT_DESCRIPTOR: IDTDescriptor = IDTDescriptor {
 /// # Safety
 ///
 /// Can only be executed within code that expects the interrupt handlers to be
-/// defined as they are above.
+/// defined as they are described in intr_handler.rs
 pub unsafe fn load() {
     IDT_DESCRIPTOR.offset = IDT.as_ptr() as u32;
 

--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -1,6 +1,6 @@
 use core::arch::asm;
 
-use crate::interrupts::timer;
+use crate::interrupts::{pic, timer};
 use crate::threading::scheduling;
 use crate::user_program::syscall;
 
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
         iretd
         ",
     sym timer::step_sys_clock,
-    sym timer::send_eoi,
+    sym pic::send_eoi,
     sym scheduling::scheduler_yield_and_continue,
     options(noreturn),
     );

--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -1,0 +1,81 @@
+use core::arch::asm;
+
+use crate::interrupts::timer;
+use crate::threading::scheduling;
+use crate::user_program::syscall;
+
+#[naked]
+pub unsafe extern "C" fn unhandled_handler() -> ! {
+    fn inner() -> ! {
+        panic!("unhandled interrupt");
+    }
+
+    asm!(
+    "call {}",
+    sym inner,
+    options(noreturn),
+    );
+}
+
+#[naked]
+pub unsafe extern "C" fn page_fault_handler() -> ! {
+    unsafe fn inner(error_code: u32, return_eip: usize) -> ! {
+        let vaddr: usize;
+        asm!("mov {}, cr2", out(reg) vaddr);
+        panic!("page fault with error code {error_code:#b} occurred when trying to access {vaddr:#X} from instruction at {return_eip:#X}");
+    }
+
+    asm!(
+    "call {}",
+    sym inner,
+    options(noreturn),
+    );
+}
+
+#[naked]
+pub unsafe extern "C" fn syscall_handler() -> ! {
+    asm!(
+    "
+        // Push arguments to stack.
+        push edx
+        push ecx
+        push ebx
+        push eax
+
+        // TODO: We need to define what our syscall ABI is allowed to clobber
+        // and what it must preserve, then actually do that. We should also
+        // investigate what actual OSs do to ensure that we're not leaking
+        // sensitive kernel data, even if we are respecting our ABI.
+
+        call {}
+        // eax will contain the handler's return value, which is where it should
+        // remain when we return to the program.
+
+        add esp, 16 // Drop arguments from stack.
+
+        iretd
+        ",
+    sym syscall::handler,
+    options(noreturn),
+    );
+}
+
+#[naked]
+pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
+    asm!(
+    "
+        // Push IRQ0 value onto the stack.
+        push 0x0
+        call {} // Update system clock
+        call {} // Send EOI signal to PICs
+        call {} // Yield process
+
+        add esp, 4 // Drop arguments from stack
+        iretd
+        ",
+    sym timer::step_sys_clock,
+    sym timer::send_eoi,
+    sym scheduling::scheduler_yield_and_continue,
+    options(noreturn),
+    );
+}

--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -4,6 +4,10 @@ use crate::interrupts::{pic, timer};
 use crate::threading::scheduling;
 use crate::user_program::syscall;
 
+/* This file contains all the interrupt handlers to be installed in the IDT when the kernel is initialized.
+ * Each must be naked function with C linkage and the type fn() -> !
+ */
+
 #[naked]
 pub unsafe extern "C" fn unhandled_handler() -> ! {
     fn inner() -> ! {
@@ -11,9 +15,9 @@ pub unsafe extern "C" fn unhandled_handler() -> ! {
     }
 
     asm!(
-    "call {}",
-    sym inner,
-    options(noreturn),
+        "call {}",
+        sym inner,
+        options(noreturn),
     );
 }
 
@@ -26,16 +30,16 @@ pub unsafe extern "C" fn page_fault_handler() -> ! {
     }
 
     asm!(
-    "call {}",
-    sym inner,
-    options(noreturn),
+        "call {}",
+        sym inner,
+        options(noreturn),
     );
 }
 
 #[naked]
 pub unsafe extern "C" fn syscall_handler() -> ! {
     asm!(
-    "
+        "
         // Push arguments to stack.
         push edx
         push ecx
@@ -55,15 +59,15 @@ pub unsafe extern "C" fn syscall_handler() -> ! {
 
         iretd
         ",
-    sym syscall::handler,
-    options(noreturn),
+        sym syscall::handler,
+        options(noreturn),
     );
 }
 
 #[naked]
 pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
     asm!(
-    "
+        "
         // Push IRQ0 value onto the stack.
         push 0x0
         call {} // Update system clock
@@ -73,9 +77,9 @@ pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
         add esp, 4 // Drop arguments from stack
         iretd
         ",
-    sym timer::step_sys_clock,
-    sym pic::send_eoi,
-    sym scheduling::scheduler_yield_and_continue,
-    options(noreturn),
+        sym timer::step_sys_clock,
+        sym pic::send_eoi,
+        sym scheduling::scheduler_yield_and_continue,
+        options(noreturn),
     );
 }

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -1,8 +1,9 @@
 pub mod idt;
-pub mod timer;
+pub mod mutex_irq;
+pub mod pic;
 
 mod intr_handler;
-pub(crate) mod mutex_irq;
+mod timer;
 
 use core::{
     arch::asm,

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -22,10 +22,10 @@ pub fn intr_get_level() -> IntrLevel {
     let flags: u32;
     unsafe {
         asm!(
-        "pushfd",
-        "mov {}, [esp]",
-        "popfd",
-        out(reg) flags
+            "pushfd",
+            "mov {}, [esp]",
+            "popfd",
+            out(reg) flags
         );
     }
 

--- a/kernel/src/interrupts/pic.rs
+++ b/kernel/src/interrupts/pic.rs
@@ -1,0 +1,96 @@
+use core::arch::asm;
+use kidneyos_shared::serial::{inb, outb};
+
+pub const PIC1_OFFSET: u8 = 0x20;
+pub const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
+
+const PIC1_CMD: u16 = 0x20;
+const PIC1_DATA: u16 = 0x21;
+const PIC2_CMD: u16 = 0xa0;
+const PIC2_DATA: u16 = 0xa1;
+
+const ICW1_ICW4: u8 = 0x01; /* Indicates that ICW4 will be present */
+const ICW1_INIT: u8 = 0x10; /* Initialization - required! */
+const ICW4_8086: u8 = 0x01; /* 8086/88 (MCS-80/85) mode */
+
+const PIC_EOI: u8 = 0x20; /* End-of-interrupt command code */
+
+pub unsafe fn pic_remap(offset1: u8, offset2: u8) {
+    // Send command: Begin 3-byte initialization sequence.
+    outb(PIC1_CMD, ICW1_INIT + ICW1_ICW4);
+    io_wait();
+    outb(PIC2_CMD, ICW1_INIT + ICW1_ICW4);
+    io_wait();
+
+    // Send data 1: Set interrupt offset.
+    outb(PIC1_DATA, offset1);
+    io_wait();
+    outb(PIC2_DATA, offset2);
+    io_wait();
+
+    // Byte 2: Configure chaining between PIC1 and PIC2.
+    outb(PIC1_DATA, 4);
+    io_wait();
+    outb(PIC2_DATA, 2);
+    io_wait();
+
+    // Send data 3: Set mode.
+    outb(PIC1_DATA, ICW4_8086);
+    io_wait();
+    outb(PIC2_DATA, ICW4_8086);
+    io_wait();
+}
+
+pub unsafe fn init_pit() {
+    // program the PIT
+    // channel 0 (bit 6-7), lo/hi-byte (bit 4-5), rate generator (bit 1-3)
+    outb(0x43, 0b00110100);
+
+    asm!(
+        "
+        mov ax, 0xffff // (reload value)
+        out 0x40, al // set low byte of PIT reload value
+        mov al, ah
+        out 0x40, al // set high byte of PIT reload value
+        ",
+    );
+
+    // unmask and activate all IRQs
+    outb(PIC1_DATA, 0x0);
+    outb(PIC2_DATA, 0x0);
+}
+
+#[allow(unused)]
+pub unsafe fn irq_mask(mut irq: u8) {
+    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
+    if irq >= 8 {
+        irq -= 8
+    };
+    let mask = inb(port) | (1 << irq);
+
+    outb(port, mask);
+}
+
+#[allow(unused)]
+pub unsafe fn irq_unmask(mut irq: u8) {
+    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
+    if irq >= 8 {
+        irq -= 8
+    };
+    let mask = inb(port) & !(1 << irq);
+
+    outb(port, mask);
+}
+
+pub unsafe fn send_eoi(irq: u8) {
+    if irq >= 8 {
+        outb(PIC2_CMD, PIC_EOI);
+    }
+
+    outb(PIC1_CMD, PIC_EOI);
+}
+
+unsafe fn io_wait() {
+    // http://wiki.osdev.org/Inline_Assembly/Examples#IO_WAIT
+    outb(0x80, 0);
+}

--- a/kernel/src/interrupts/timer.rs
+++ b/kernel/src/interrupts/timer.rs
@@ -1,4 +1,5 @@
-use crate::{sync::irq::MutexIrq, threading::scheduling::scheduler_yield_and_continue};
+use super::mutex_irq::MutexIrq;
+use crate::threading::scheduling::scheduler_yield_and_continue;
 use core::{arch::asm, time::Duration};
 use kidneyos_shared::serial::{inb, outb};
 

--- a/kernel/src/interrupts/timer.rs
+++ b/kernel/src/interrupts/timer.rs
@@ -1,21 +1,6 @@
 use super::mutex_irq::MutexIrq;
 use crate::threading::scheduling::scheduler_yield_and_continue;
-use core::{arch::asm, time::Duration};
-use kidneyos_shared::serial::{inb, outb};
-
-pub const PIC1_OFFSET: u8 = 0x20;
-pub const PIC2_OFFSET: u8 = PIC1_OFFSET + 8;
-
-const PIC1_CMD: u16 = 0x20;
-const PIC1_DATA: u16 = 0x21;
-const PIC2_CMD: u16 = 0xa0;
-const PIC2_DATA: u16 = 0xa1;
-
-const ICW1_ICW4: u8 = 0x01; /* Indicates that ICW4 will be present */
-const ICW1_INIT: u8 = 0x10; /* Initialization - required! */
-const ICW4_8086: u8 = 0x01; /* 8086/88 (MCS-80/85) mode */
-
-const PIC_EOI: u8 = 0x20; /* End-of-interrupt command code */
+use core::time::Duration;
 
 // PIT generates 3579545 / 3 Hz input signal which we wait to receive 0xffff (65535) of before sending a timer interrupt.
 // This gives us an interval of 0xffff * 3 / 3579545 seconds between each timer interrupt
@@ -24,86 +9,6 @@ pub const TIMER_INTERRUPT_INTERVAL: Duration =
     Duration::from_micros((10u64).pow(6) * 0xffff * 3 / 3579545);
 
 static SYS_CLOCK: MutexIrq<Duration> = MutexIrq::new(Duration::new(0, 0));
-
-pub unsafe fn pic_remap(offset1: u8, offset2: u8) {
-    // Send command: Begin 3-byte initialization sequence.
-    outb(PIC1_CMD, ICW1_INIT + ICW1_ICW4);
-    io_wait();
-    outb(PIC2_CMD, ICW1_INIT + ICW1_ICW4);
-    io_wait();
-
-    // Send data 1: Set interrupt offset.
-    outb(PIC1_DATA, offset1);
-    io_wait();
-    outb(PIC2_DATA, offset2);
-    io_wait();
-
-    // Byte 2: Configure chaining between PIC1 and PIC2.
-    outb(PIC1_DATA, 4);
-    io_wait();
-    outb(PIC2_DATA, 2);
-    io_wait();
-
-    // Send data 3: Set mode.
-    outb(PIC1_DATA, ICW4_8086);
-    io_wait();
-    outb(PIC2_DATA, ICW4_8086);
-    io_wait();
-}
-
-pub unsafe fn init_pit() {
-    // program the PIT
-    // channel 0 (bit 6-7), lo/hi-byte (bit 4-5), rate generator (bit 1-3)
-    outb(0x43, 0b00110100);
-
-    asm!(
-        "
-        mov ax, 0xffff // (reload value)
-        out 0x40, al // set low byte of PIT reload value
-        mov al, ah
-        out 0x40, al // set high byte of PIT reload value
-        ",
-    );
-
-    // unmask and activate all IRQs
-    outb(PIC1_DATA, 0x0);
-    outb(PIC2_DATA, 0x0);
-}
-
-#[allow(unused)]
-pub unsafe fn irq_mask(mut irq: u8) {
-    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
-    if irq >= 8 {
-        irq -= 8
-    };
-    let mask = inb(port) | (1 << irq);
-
-    outb(port, mask);
-}
-
-#[allow(unused)]
-pub unsafe fn irq_unmask(mut irq: u8) {
-    let port = if irq < 8 { PIC1_DATA } else { PIC2_DATA };
-    if irq >= 8 {
-        irq -= 8
-    };
-    let mask = inb(port) & !(1 << irq);
-
-    outb(port, mask);
-}
-
-pub unsafe fn send_eoi(irq: u8) {
-    if irq >= 8 {
-        outb(PIC2_CMD, PIC_EOI);
-    }
-
-    outb(PIC1_CMD, PIC_EOI);
-}
-
-unsafe fn io_wait() {
-    // http://wiki.osdev.org/Inline_Assembly/Examples#IO_WAIT
-    outb(0x80, 0);
-}
 
 pub fn step_sys_clock() {
     let mut clock = SYS_CLOCK.lock();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -22,7 +22,7 @@ mod user_program;
 extern crate alloc;
 
 use crate::block::block_core::block_init;
-use interrupts::{idt, timer};
+use interrupts::{idt, pic};
 use kidneyos_shared::{global_descriptor_table, println, video_memory::VIDEO_MEMORY_WRITER};
 use mem::KernelAllocator;
 use threading::{thread_system_initialization, thread_system_start};
@@ -62,8 +62,8 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
         println!("GDTR set up!");
 
         println!("Setting up PIT");
-        timer::pic_remap(timer::PIC1_OFFSET, timer::PIC2_OFFSET);
-        timer::init_pit();
+        pic::pic_remap(pic::PIC1_OFFSET, pic::PIC2_OFFSET);
+        pic::init_pit();
         println!("PIT set up!");
 
         println!("Setting up block layer");

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -12,17 +12,17 @@
 
 mod block;
 mod drivers;
-mod interrupt_descriptor_table;
+mod interrupts;
 mod mem;
 mod paging;
 mod sync;
 mod threading;
-mod timer;
 mod user_program;
 
 extern crate alloc;
 
 use crate::block::block_core::block_init;
+use interrupts::{idt, timer};
 use kidneyos_shared::{global_descriptor_table, println, video_memory::VIDEO_MEMORY_WRITER};
 use mem::KernelAllocator;
 use threading::{thread_system_initialization, thread_system_start};
@@ -50,7 +50,7 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
         KERNEL_ALLOCATOR.init(mem_upper);
 
         println!("Setting up IDTR");
-        interrupt_descriptor_table::load();
+        idt::load();
         println!("IDTR set up!");
 
         println!("Enabling paging");

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,5 +1,2 @@
-pub mod intr;
-#[allow(unused)]
-pub mod irq;
 #[allow(unused)]
 pub mod mutex;

--- a/kernel/src/threading/context_switch.rs
+++ b/kernel/src/threading/context_switch.rs
@@ -1,4 +1,4 @@
-use crate::sync::intr::{intr_get_level, IntrLevel};
+use crate::interrupts::{intr_get_level, IntrLevel};
 use core::mem::offset_of;
 
 use alloc::boxed::Box;

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -4,8 +4,8 @@ pub mod thread_control_block;
 pub mod thread_functions;
 
 use crate::{
+    interrupts::{intr_enable, intr_get_level, IntrLevel},
     paging::PageManager,
-    sync::intr::{intr_enable, intr_get_level, IntrLevel},
     threading::scheduling::{initialize_scheduler, scheduler_yield_and_continue, SCHEDULER},
 };
 use alloc::boxed::Box;

--- a/kernel/src/threading/scheduling/mod.rs
+++ b/kernel/src/threading/scheduling/mod.rs
@@ -6,7 +6,7 @@ pub use scheduler::Scheduler;
 
 use alloc::boxed::Box;
 
-use crate::sync::intr::{hold_interrupts, intr_get_level, IntrLevel};
+use crate::interrupts::{intr_get_level, mutex_irq::hold_interrupts, IntrLevel};
 
 use super::{context_switch::switch_threads, thread_control_block::ThreadStatus};
 

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -4,7 +4,7 @@ use super::{
     RUNNING_THREAD,
 };
 use crate::{
-    sync::intr::{intr_disable, intr_enable},
+    interrupts::{intr_disable, intr_enable},
     threading::scheduling::scheduler_yield_and_die,
 };
 use alloc::boxed::Box;


### PR DESCRIPTION
Currently, the code which setups and handles our interrupt flow is scattered around various files which aren't all named accordingly. This just refactors all the interrupt-related code into one module. This should also simplify interacting with it for people unfamiliar with the process system as there is now a clear place to setup interrupt handlers.