### PR TITLE
Add some basic functions for accessing userspace pointers

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,11 +9,12 @@
 #![feature(offset_of)]
 #![feature(slice_ptr_get)]
 #![feature(negative_impls)]
+#![feature(pointer_is_aligned)]
 
 mod block;
 mod drivers;
 mod interrupts;
-mod mem;
+pub mod mem;
 mod paging;
 mod sync;
 mod threading;

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -1,5 +1,6 @@
 mod buddy_allocator;
 mod frame_allocator;
+pub mod util;
 
 use alloc::vec::Vec;
 use buddy_allocator::BuddyAllocator;
@@ -150,6 +151,9 @@ impl KernelAllocator {
         };
     }
 
+    /// # Safety
+    ///
+    /// TODO
     pub unsafe fn frame_alloc(&mut self, frames: usize) -> Result<NonNull<[u8]>, AllocError> {
         let KernelAllocatorState::Initialized {
             frame_allocator, ..
@@ -161,6 +165,9 @@ impl KernelAllocator {
         frame_allocator.alloc(frames)
     }
 
+    /// # Safety
+    ///
+    /// TODO
     pub unsafe fn frame_dealloc(&mut self, ptr: NonNull<u8>) {
         let KernelAllocatorState::Initialized {
             frame_allocator, ..

--- a/kernel/src/mem/util.rs
+++ b/kernel/src/mem/util.rs
@@ -1,0 +1,135 @@
+use crate::paging::{is_userspace_readable, is_userspace_writeable};
+
+pub enum CStrError {
+    Fault,
+    BadUtf8,
+}
+
+/// Minimum possible page size. It's okay for this to be smaller than the actual page size.
+const MIN_PAGE_SIZE: usize = 4096;
+
+#[must_use]
+fn can_access_address_range(start: *const u8, bytes: usize, write: bool) -> bool {
+    let check = if write {
+        is_userspace_writeable
+    } else {
+        is_userspace_readable
+    };
+    if !check(start) {
+        return false;
+    }
+    let Some(end) = (start as usize).checked_add(bytes) else {
+        // addition overflows so this definitely isn't valid
+        return false;
+    };
+    // round up to nearest page
+    let mut p = (start as usize).div_ceil(MIN_PAGE_SIZE) * MIN_PAGE_SIZE;
+    while p + MIN_PAGE_SIZE < end {
+        if !check(p as *const u8) {
+            return false;
+        }
+        p += MIN_PAGE_SIZE;
+    }
+    true
+}
+
+/// Construct null-terminated string from userspace pointer
+///
+/// # Safety
+///
+/// The returned reference is invalidated if the page(s) containing the string are mapped out of memory.
+/// You must not hold any mutable references to any parts of the string
+/// while it is in scope (as is required by Rust).
+/// TODO: this doesn't actually check that ptr is mapped yet.
+pub unsafe fn get_cstr_from_user_space(ptr: *const u8) -> Result<&'static str, CStrError> {
+    let mut len = 0usize;
+    if !is_userspace_readable(ptr) {
+        return Err(CStrError::Fault);
+    }
+    loop {
+        if *ptr.add(len) == 0 {
+            break;
+        }
+        len += 1;
+        let Some(end) = (ptr as usize).checked_add(len) else {
+            return Err(CStrError::Fault);
+        };
+        if end % MIN_PAGE_SIZE == 0 && !is_userspace_readable(end as *const u8) {
+            return Err(CStrError::Fault);
+        }
+    }
+    let slice: &'static [u8] = core::slice::from_raw_parts(ptr, len);
+    core::str::from_utf8(slice).map_err(|_| CStrError::BadUtf8)
+}
+
+/// Construct mutable slice from userspace pointer
+///
+/// Returns `None` if the pointer is not writeable for the given count of items of type `T`, or if it's not aligned to type `T`.
+///
+/// # Safety
+///
+/// The returned reference is invalidated if the page(s) containing the string are mapped out of memory.
+/// You must not hold any other mutable references to any parts of the slice
+/// while it is in scope (as is required by Rust).
+/// Additionally, `ptr[..len]` must only contain valid values for `T` (e.g. it can't contain the byte `2` if `T` is `bool`).
+///
+/// TODO: this doesn't actually check that ptr is mapped yet.
+pub unsafe fn get_mut_slice_from_user_space<T>(
+    ptr: *mut u8,
+    count: usize,
+) -> Option<&'static mut [T]> {
+    let bytes = count.checked_mul(core::mem::size_of::<T>())?;
+    if !can_access_address_range(ptr, bytes, true) {
+        return None;
+    }
+    let ptr: *mut T = ptr.cast();
+    if !ptr.is_aligned() {
+        return None;
+    }
+    Some(core::slice::from_raw_parts_mut(ptr.cast(), count))
+}
+
+/// Construct slice from userspace pointer
+///
+/// Returns `None` if the pointer is not readable for the given count of items of type `T`, or if it's not aligned to type `T`.
+///
+/// # Safety
+///
+/// The returned reference is invalidated if the page(s) containing the string are mapped out of memory.
+/// You must not hold any mutable references to any parts of the slice
+/// while it is in scope (as is required by Rust).
+///
+/// TODO: this doesn't actually check that ptr is mapped yet.
+pub unsafe fn get_slice_from_user_space<T>(ptr: *const u8, count: usize) -> Option<&'static [T]> {
+    let bytes = count.checked_mul(core::mem::size_of::<T>())?;
+    if !can_access_address_range(ptr, bytes, false) {
+        return None;
+    }
+    let ptr: *const T = ptr.cast();
+    if !ptr.is_aligned() {
+        return None;
+    }
+    Some(core::slice::from_raw_parts(ptr, count))
+}
+
+/// Construct mutable reference from userspace pointer.
+///
+/// Returns `None` if the pointer is not writeable, or if it's not aligned to type `T`.
+///
+/// # Safety
+///
+/// See [`get_mut_slice_from_user_space`].
+pub unsafe fn get_mut_from_user_space<T>(ptr: *mut u8) -> Option<&'static mut T> {
+    Some(&mut get_mut_slice_from_user_space(ptr, 1)?[0])
+}
+
+/// Construct reference from userspace pointer.
+///
+/// Returns `None` if the pointer is not readable, or if it's not aligned to type `T`.
+///
+/// # Safety
+///
+/// See [`get_slice_from_user_space`].
+pub unsafe fn get_ref_from_user_space<T>(ptr: *const u8) -> Option<&'static T> {
+    Some(&get_slice_from_user_space(ptr, 1)?[0])
+}

--- a/kernel/src/mem/util.rs
+++ b/kernel/src/mem/util.rs
@@ -9,7 +9,7 @@ pub enum CStrError {
 const MIN_PAGE_SIZE: usize = 4096;
 
 #[must_use]
-fn can_access_address_range(start: *const u8, bytes: usize, write: bool) -> bool {
+fn can_access_address_range<T>(start: *const T, bytes: usize, write: bool) -> bool {
     let check = if write {
         is_userspace_writeable
     } else {
@@ -25,7 +25,7 @@ fn can_access_address_range(start: *const u8, bytes: usize, write: bool) -> bool
     // round up to nearest page
     let mut p = (start as usize).div_ceil(MIN_PAGE_SIZE) * MIN_PAGE_SIZE;
     while p + MIN_PAGE_SIZE < end {
-        if !check(p as *const u8) {
+        if !check(p as *const T) {
             return false;
         }
         p += MIN_PAGE_SIZE;
@@ -82,7 +82,7 @@ pub unsafe fn get_mut_slice_from_user_space<T>(
         return None;
     }
     let bytes = count.checked_mul(core::mem::size_of::<T>())?;
-    if !can_access_address_range(ptr as _, bytes, true) {
+    if !can_access_address_range(ptr, bytes, true) {
         return None;
     }
     Some(core::slice::from_raw_parts_mut(ptr.cast(), count))
@@ -105,7 +105,7 @@ pub unsafe fn get_slice_from_user_space<T>(ptr: *const T, count: usize) -> Optio
         return None;
     }
     let bytes = count.checked_mul(core::mem::size_of::<T>())?;
-    if !can_access_address_range(ptr as _, bytes, false) {
+    if !can_access_address_range(ptr, bytes, false) {
         return None;
     }
     let ptr: *const T = ptr.cast();

--- a/kernel/src/mem/util.rs
+++ b/kernel/src/mem/util.rs
@@ -68,10 +68,10 @@ pub unsafe fn get_cstr_from_user_space(ptr: *const u8) -> Result<&'static str, C
 ///
 /// # Safety
 ///
-/// The returned reference is invalidated if the page(s) containing the string are mapped out of memory.
+/// The returned reference is invalidated if the page(s) containing the slice are mapped out of memory.
 /// You must not hold any other mutable references to any parts of the slice
 /// while it is in scope (as is required by Rust).
-/// Additionally, `ptr[..len]` must only contain valid values for `T` (e.g. it can't contain the byte `2` if `T` is `bool`).
+/// Additionally, `ptr[..count]` must only contain valid values for `T` (e.g. it can't contain the byte `2` if `T` is `bool`).
 ///
 /// TODO: this doesn't actually check that ptr is mapped yet.
 pub unsafe fn get_mut_slice_from_user_space<T>(
@@ -95,9 +95,10 @@ pub unsafe fn get_mut_slice_from_user_space<T>(
 ///
 /// # Safety
 ///
-/// The returned reference is invalidated if the page(s) containing the string are mapped out of memory.
+/// The returned reference is invalidated if the page(s) containing the slice are mapped out of memory.
 /// You must not hold any mutable references to any parts of the slice
 /// while it is in scope (as is required by Rust).
+/// Additionally, `ptr[..count]` must only contain valid values for `T` (e.g. it can't contain the byte `2` if `T` is `bool`).
 ///
 /// TODO: this doesn't actually check that ptr is mapped yet.
 pub unsafe fn get_slice_from_user_space<T>(ptr: *const u8, count: usize) -> Option<&'static [T]> {

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -21,3 +21,21 @@ pub unsafe fn enable() -> PageManager {
     page_manager.load();
     page_manager
 }
+
+pub fn is_userspace_readable(ptr: *const u8) -> bool {
+    if (ptr as isize) <= 0 {
+        // null or kernel-space address
+        return false;
+    }
+    // TODO: check page table
+    true
+}
+
+pub fn is_userspace_writeable(ptr: *const u8) -> bool {
+    if (ptr as isize) <= 0 {
+        // null or kernel-space address
+        return false;
+    }
+    // TODO: check page table
+    true
+}

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -22,7 +22,7 @@ pub unsafe fn enable() -> PageManager {
     page_manager
 }
 
-pub fn is_userspace_readable(ptr: *const u8) -> bool {
+pub fn is_userspace_readable<T>(ptr: *const T) -> bool {
     if (ptr as isize) <= 0 {
         // null or kernel-space address
         return false;
@@ -31,7 +31,7 @@ pub fn is_userspace_readable(ptr: *const u8) -> bool {
     true
 }
 
-pub fn is_userspace_writeable(ptr: *const u8) -> bool {
+pub fn is_userspace_writeable<T>(ptr: *const T) -> bool {
     if (ptr as isize) <= 0 {
         // null or kernel-space address
         return false;


### PR DESCRIPTION
Add some functions so that we can access userspace pointers passed in from syscalls. Currently this is incomplete, since we need to check whether the pointers are actually mapped (e.g. on Linux at least, `open((void *)0x1234, 0)` returns `-EFAULT` rather than causing an interrupt). But it's good to at least have a version we can use for now.

Also I'm assuming we're following the Linux convention of pointers `>= 0x8000_0000` corresponding to kernel-space, but I'm not sure if that's true (seems to be as far as I can tell).