### PR TITLE
Add PCB functionality back

### DIFF
--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -5,6 +5,7 @@ pub mod thread_control_block;
 pub mod thread_functions;
 pub mod thread_sleep;
 
+use crate::threading::process_table::initialize_process_table;
 use crate::user_program::elf::Elf;
 use crate::{
     interrupts::{intr_enable, intr_get_level, IntrLevel},
@@ -12,7 +13,7 @@ use crate::{
     threading::scheduling::{initialize_scheduler, scheduler_yield_and_continue, SCHEDULER},
 };
 use alloc::boxed::Box;
-use thread_control_block::{initialize_process_table, ThreadControlBlock};
+use thread_control_block::ThreadControlBlock;
 
 pub static mut RUNNING_THREAD: Option<Box<ThreadControlBlock>> = None;
 
@@ -22,7 +23,7 @@ static mut THREAD_SYSTEM_INITIALIZED: bool = false;
 pub fn thread_system_initialization() {
     assert_eq!(intr_get_level(), IntrLevel::IntrOff);
 
-    // Initalize the process table
+    // Initialize the process table
     initialize_process_table();
 
     // Initialize the scheduler.

--- a/kernel/src/threading/process_table.rs
+++ b/kernel/src/threading/process_table.rs
@@ -2,6 +2,14 @@ use super::thread_control_block::{Pid, ProcessControlBlock};
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 
+pub static mut PROCESS_TABLE: Option<Box<ProcessTable>> = None;
+
+pub fn initialize_process_table() {
+    unsafe {
+        PROCESS_TABLE = Some(Box::new(ProcessTable::new()));
+    }
+}
+
 pub struct ProcessTable {
     table: BTreeMap<Pid, Box<ProcessControlBlock>>,
 }

--- a/kernel/src/threading/process_table.rs
+++ b/kernel/src/threading/process_table.rs
@@ -15,7 +15,6 @@ pub struct ProcessTable {
 }
 
 impl ProcessTable {
-    #![allow(dead_code)]
     pub fn new() -> ProcessTable {
         ProcessTable {
             table: BTreeMap::new(),

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -71,7 +71,7 @@ impl ProcessControlBlock {
             exit_code: None,
         };
         unsafe {
-            PROCESS_TABLE.as_mut().expect("").add(Box::new(pcb));
+            PROCESS_TABLE.as_mut().unwrap().add(Box::new(pcb));
         }
 
         pid


### PR DESCRIPTION
Creates the PCB when necessary and ownership of them is handed to a global `PROCESS_TABLE`.