### PR TITLE
Push registers before handling interrupts

### DIFF
--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -69,6 +69,7 @@ pub unsafe extern "C" fn syscall_handler() -> ! {
 pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
     asm!(
         "
+        pusha
         // Push IRQ0 value onto the stack.
         push 0x0
         call {} // Update system clock
@@ -76,6 +77,7 @@ pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
         call {} // Yield process
 
         add esp, 4 // Drop arguments from stack
+        popa
         iretd
         ",
         sym timer::step_sys_clock,
@@ -89,6 +91,7 @@ pub unsafe extern "C" fn timer_interrupt_handler() -> ! {
 pub unsafe extern "C" fn ide_prim_interrupt_handler() -> ! {
     asm!(
     "
+    pusha
     // Push IRQ14 value onto the stack.
     push 0XE
     call {} // Send irq signal to ATA
@@ -96,6 +99,7 @@ pub unsafe extern "C" fn ide_prim_interrupt_handler() -> ! {
     call {} // Yield process
 
     add esp, 4 // Drop arguments from stack
+    popa
     iretd
     ",
     sym ata_interrupt::on_ide_interrupt,
@@ -109,6 +113,7 @@ pub unsafe extern "C" fn ide_prim_interrupt_handler() -> ! {
 pub unsafe extern "C" fn ide_secd_interrupt_handler() -> ! {
     asm!(
     "
+    pusha
     // Push IRQ15 value onto the stack.
     push 0XF
     call {} // Send irq signal to ATA
@@ -116,6 +121,7 @@ pub unsafe extern "C" fn ide_secd_interrupt_handler() -> ! {
     call {} // Yield process
 
     add esp, 4 // Drop arguments from stack
+    popa
     iretd
     ",
     sym ata_interrupt::on_ide_interrupt,

--- a/syscalls.mk
+++ b/syscalls.mk
@@ -3,7 +3,7 @@ PROJECT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 # Stubs are explicitly debug so they don't get inlined.
 SYSCALL_LIB := $(PROJECT_DIR)build/target/i686-unknown-linux-gnu/debug/libkidneyos_syscalls.rlib
 
-$(SYSCALL_LIB):
+$(SYSCALL_LIB): $(PROJECT_DIR)syscalls/src/lib.rs
 	cd $(PROJECT_DIR)syscalls && cargo build
 
 clean-syscall:


### PR DESCRIPTION
I was getting really weird bugs and I think I tracked down the problem: interrupt handlers were overwriting register values in the middle of the program's execution.

![bochs](https://github.com/user-attachments/assets/cf0e57ab-4379-4cde-aba6-d3767db14fe2)
(This instruction should be just executed once. But instead, we break on it the first time and see the correct register values, and then click "continue" and hit the breakpoint again, this time with random garbage register values)

If we look at [an interrupt handler from another operating system](https://github.com/cfenollosa/os-tutorial/blob/master/18-interrupts/cpu/interrupt.asm), they use `pusha`/`popa` to preserve the values of the registers across the interrupt.

(Also unrelatedly I added the syscalls lib.rs to the syscall lib dependencies, because otherwise the syscalls library doesn't get rebuilt when lib.rs is changed.)