### PR TITLE
Disable SSE instructions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,4 @@ target = "i686-unknown-linux-gnu"
 
 [target.i686-unknown-linux-gnu]
 linker = "i686-unknown-linux-gnu-cc"
-rustflags = ["-C", "link-arg=-e _start -nostartfiles"]
+rustflags = ["-C", "link-arg=-e _start -nostartfiles", "-C", "target-feature=-sse"]

--- a/syscalls/.cargo/config.toml
+++ b/syscalls/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "i686-unknown-linux-gnu"
+
+[target.i686-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=-sse"]


### PR DESCRIPTION
Rust likes to generate SSE instructions for 64-bit loads/stores, which leads to an invalid instruction exception, since qemu i386 system doesn't support SSE.