### PR TITLE
Make `SleepMutex::lock` take `&self`

### DIFF
--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,3 +1,3 @@
-#[allow(unused)]
+#[allow(dead_code)]
 pub mod mutex;
 pub mod semaphore;

--- a/kernel/src/sync/mutex/sleep.rs
+++ b/kernel/src/sync/mutex/sleep.rs
@@ -106,7 +106,7 @@ impl<T> SleepMutex<T> {
 }
 
 impl<T: ?Sized> SleepMutex<T> {
-    #[must_use = "Mutex is released when guard falls out of scpe"]
+    #[must_use = "Mutex is released when guard falls out of scope."]
     pub fn lock(&self) -> SleepMutexGuard<T> {
         let current_tid = unsafe {
             RUNNING_THREAD

--- a/kernel/src/sync/mutex/sleep.rs
+++ b/kernel/src/sync/mutex/sleep.rs
@@ -1,5 +1,5 @@
 use crate::{
-    interrupts::{intr_disable, intr_enable, mutex_irq::MutexIrq},
+    interrupts::mutex_irq::MutexIrq,
     threading::{
         thread_control_block::{AtomicTid, Tid},
         thread_sleep::{thread_sleep, thread_wakeup},

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -17,10 +17,12 @@ use kidneyos_shared::mem::{OFFSET, PAGE_FRAME_SIZE};
 
 pub type Pid = u16;
 pub type Tid = u16;
+pub type AtomicPid = AtomicU16;
+pub type AtomicTid = AtomicU16;
 
 // Current value marks the next available PID & TID values to use.
-static NEXT_UNRESERVED_PID: AtomicU16 = AtomicU16::new(0);
-static NEXT_UNRESERVED_TID: AtomicU16 = AtomicU16::new(0);
+static NEXT_UNRESERVED_PID: AtomicPid = AtomicPid::new(1);
+static NEXT_UNRESERVED_TID: AtomicTid = AtomicTid::new(1);
 
 // The stack size choice is based on that of x86-64 Linux and 32-bit Windows
 // Linux: https://docs.kernel.org/next/x86/kernel-stacks.html
@@ -43,11 +45,19 @@ pub enum ThreadStatus {
 
 pub fn allocate_pid() -> Pid {
     // SAFETY: Atomically accesses a shared variable.
-    NEXT_UNRESERVED_PID.fetch_add(1, Ordering::SeqCst) as Pid
+    let pid = NEXT_UNRESERVED_PID.fetch_add(1, Ordering::SeqCst) as Pid;
+    if pid == 0 {
+        panic!("PID overflow"); // TODO: handle overflow properly
+    }
+    pid
 }
 pub fn allocate_tid() -> Tid {
     // SAFETY: Atomically accesses a shared variable.
-    NEXT_UNRESERVED_TID.fetch_add(1, Ordering::SeqCst) as Tid
+    let tid = NEXT_UNRESERVED_TID.fetch_add(1, Ordering::SeqCst) as Tid;
+    if tid == 0 {
+        panic!("TID overflow");
+    }
+    tid
 }
 
 pub struct ProcessControlBlock {


### PR DESCRIPTION
Currently SleepMutex isn't very useful, since its lock method requires `&mut self`, and you can't have multiple mutable references at once to a value in Rust.
We can make `SleepMutex` take `&self` (as `std::sync::Mutex` does) by making the `holding_thread` atomic and using a `MutexIrq` to store the wait queue.
I have removed `force_unlock`, since `std::sync::Mutex` doesn't even have it (but lmk if you want to add it back in).