### PR TITLE
Fix Residual Characters when Scrolling in VideoMemoryWriter

### DIFF
--- a/shared/src/video_memory.rs
+++ b/shared/src/video_memory.rs
@@ -84,8 +84,8 @@ impl fmt::Write for VideoMemoryWriter {
                 let start = VIDEO_MEMORY_SIZE - VIDEO_MEMORY_COLS;
                 let end = VIDEO_MEMORY_SIZE;
 
-                for i in start..end {
-                    video_memory[i] = Character {
+                for c in &mut video_memory[start..end] {
+                    *c = Character {
                         ascii: b' ',
                         attribute: self.attribute,
                     };

--- a/shared/src/video_memory.rs
+++ b/shared/src/video_memory.rs
@@ -79,6 +79,18 @@ impl fmt::Write for VideoMemoryWriter {
         for b in s.as_bytes() {
             if self.cursor >= video_memory.len() {
                 video_memory.copy_within(VIDEO_MEMORY_COLS..VIDEO_MEMORY_SIZE, 0);
+
+                // Clear previous line.
+                let start = VIDEO_MEMORY_SIZE - VIDEO_MEMORY_COLS;
+                let end = VIDEO_MEMORY_SIZE;
+
+                for i in start..end {
+                    video_memory[i] = Character {
+                        ascii: b' ',
+                        attribute: self.attribute,
+                    };
+                }
+
                 self.cursor = VIDEO_MEMORY_SIZE - VIDEO_MEMORY_COLS;
             }
 


### PR DESCRIPTION
> **Note:** The linter suggested using an iterator, so I tried the following:
> ```rust
>                 for char in video_memory.iter_mut().take(end).skip(start) {
>                     *char = Character {
>                         ascii: b' ',
>                         attribute: self.attribute,
>                     };
>                 }
> ```
> However, this didn't work as expected. Could someone suggest a fix?

Fix the issue in the `VideoMemoryWriter` where residual characters remain on the screen after scrolling.

<img width="832" alt="Screenshot 2024-10-19 at 6 38 03 PM" src="https://github.com/user-attachments/assets/2ba5dfec-6185-49b6-8740-3e3a112cf1e3">