### PR TITLE
Implement RwLock

### DIFF
--- a/kernel/src/interrupts/mutex_irq.rs
+++ b/kernel/src/interrupts/mutex_irq.rs
@@ -71,10 +71,6 @@ impl<T: ?Sized> MutexIrq<T> {
         self.lock.is_locked()
     }
 
-    pub unsafe fn force_unlock(&self) {
-        self.lock.force_unlock()
-    }
-
     #[inline(always)]
     pub fn try_lock(&self) -> Option<MutexGuardIrq<T>> {
         if self.lock.is_locked() {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -18,7 +18,7 @@ pub mod fs;
 mod interrupts;
 pub mod mem;
 mod paging;
-mod sync;
+pub mod sync;
 mod system;
 mod threading;
 mod user_program;

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -1,3 +1,4 @@
 #[allow(dead_code)]
 pub mod mutex;
+pub mod rwlock;
 pub mod semaphore;

--- a/kernel/src/sync/mutex.rs
+++ b/kernel/src/sync/mutex.rs
@@ -52,11 +52,6 @@ impl<T: ?Sized> Mutex<T> {
     }
 
     #[inline(always)]
-    pub unsafe fn force_unlock(&self) {
-        self.inner.force_unlock()
-    }
-
-    #[inline(always)]
     pub fn is_locked(&self) -> bool {
         self.inner.is_locked()
     }

--- a/kernel/src/sync/mutex/sleep.rs
+++ b/kernel/src/sync/mutex/sleep.rs
@@ -1,5 +1,5 @@
 use crate::interrupts::mutex_irq::MutexIrq;
-use crate::system::{unwrap_system, unwrap_system_mut};
+use crate::system::running_thread_tid;
 use crate::threading::process::{AtomicTid, Tid};
 use crate::threading::thread_sleep::{thread_sleep, thread_wakeup};
 use alloc::collections::VecDeque;
@@ -104,16 +104,12 @@ impl<T> SleepMutex<T> {
 impl<T: ?Sized> SleepMutex<T> {
     #[must_use = "Mutex is released when guard falls out of scope."]
     pub fn lock(&self) -> SleepMutexGuard<T> {
-        let current_tid = unsafe {
-            unwrap_system_mut()
-                .threads
-                .running_thread
-                .as_ref()
-                .expect("why is nothing running?")
-                .tid
-        };
+        let current_tid = running_thread_tid();
 
         loop {
+            // Ensure interrupts are disabled *before* we check the lock state,
+            // so that the owner of the Mutex will definitely wake us up when we go to sleep.
+            let mut wait_queue = self.wait_queue.lock();
             // If no thread is holding the mutex, grab it.
             let _ = self
                 .holding_thread
@@ -125,7 +121,6 @@ impl<T: ?Sized> SleepMutex<T> {
                 break;
             }
 
-            let mut wait_queue = self.wait_queue.lock();
             if !wait_queue.contains(&current_tid) {
                 wait_queue.push_back(current_tid);
             }
@@ -137,14 +132,7 @@ impl<T: ?Sized> SleepMutex<T> {
     }
 
     fn unlock(&self) {
-        let running_tid = unsafe {
-            unwrap_system()
-                .threads
-                .running_thread
-                .as_ref()
-                .expect("why is nothing running?")
-                .tid
-        };
+        let running_tid = running_thread_tid();
 
         if self.holding_thread.load(Acquire) != running_tid {
             return;
@@ -167,14 +155,7 @@ impl<T: ?Sized> SleepMutex<T> {
     }
 
     pub fn try_lock(&self) -> bool {
-        let current_tid = unsafe {
-            unwrap_system()
-                .threads
-                .running_thread
-                .as_ref()
-                .expect("why is nothing running?")
-                .tid
-        };
+        let current_tid = running_thread_tid();
         self.holding_thread
             .compare_exchange(0, current_tid, AcqRel, Acquire)
             .is_ok()

--- a/kernel/src/sync/mutex/ticket.rs
+++ b/kernel/src/sync/mutex/ticket.rs
@@ -85,11 +85,6 @@ impl<T: ?Sized> TicketMutex<T> {
     }
 
     #[inline(always)]
-    pub unsafe fn force_unlock(&self) {
-        self.next_serving.fetch_add(1, Ordering::Release);
-    }
-
-    #[inline(always)]
     pub fn try_lock(&self) -> Option<TicketMutexGuard<T>> {
         let ticket = self
             .next_ticket

--- a/kernel/src/sync/rwlock/mod.rs
+++ b/kernel/src/sync/rwlock/mod.rs
@@ -1,0 +1,1 @@
+pub mod sleep;

--- a/kernel/src/sync/rwlock/sleep.rs
+++ b/kernel/src/sync/rwlock/sleep.rs
@@ -1,0 +1,158 @@
+use crate::sync::mutex::Mutex;
+use crate::system::running_thread_tid;
+use crate::threading::process::Tid;
+use crate::threading::thread_sleep::{thread_sleep, thread_wakeup};
+use alloc::collections::VecDeque;
+use core::cell::UnsafeCell;
+
+struct Waiter {
+    is_writer: bool,
+    tid: Tid,
+}
+
+struct RwLockState {
+    reader_count: usize,
+    any_writer: bool,
+    wait_queue: VecDeque<Waiter>,
+}
+
+/// A read-write lock, like `std::sync::RwLock`.
+///
+/// This lock can be acquired for either reading (`&T`) or writing (`&mut T`).
+/// It allows any number of concurrent readers, but only one writer at a time.
+pub struct RwLock<T> {
+    state: Mutex<RwLockState>,
+    data: UnsafeCell<T>,
+}
+
+pub struct RwLockReadGuard<'a, T> {
+    lock: &'a RwLock<T>,
+}
+
+pub struct RwLockWriteGuard<'a, T> {
+    lock: &'a RwLock<T>,
+}
+
+impl<T> core::ops::Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The fact that we have a read guard means that there are no writers currently.
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T> core::ops::Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The fact that we have a write guard means that there are no other readers currently.
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T> core::ops::DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: The fact that we have a write guard means that there are no other readers or writers currently.
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<'a, T> Drop for RwLockReadGuard<'a, T> {
+    fn drop(&mut self) {
+        let mut state = self.lock.state.lock();
+        let needs_wakeup = state.reader_count == 1 && !state.wait_queue.is_empty();
+        debug_assert!(!state.any_writer);
+        state.reader_count -= 1;
+        drop(state);
+        if needs_wakeup {
+            // we were the last reader, so wake up any sleeping writers
+            self.lock.wakeup();
+        }
+    }
+}
+
+impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        let mut state = self.lock.state.lock();
+        let needs_wakeup = !state.wait_queue.is_empty();
+        debug_assert!(state.reader_count == 0);
+        state.any_writer = false;
+        drop(state);
+        if needs_wakeup {
+            // wake up any sleeping readers/writers
+            self.lock.wakeup();
+        }
+    }
+}
+
+impl<T> RwLock<T> {
+    /// Create new RwLock with data
+    pub const fn new(data: T) -> Self {
+        Self {
+            state: Mutex::new(RwLockState {
+                any_writer: false,
+                reader_count: 0,
+                wait_queue: VecDeque::new(),
+            }),
+            data: UnsafeCell::new(data),
+        }
+    }
+    /// Acquire the lock for reading.
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        loop {
+            let mut state = self.state.lock();
+            if state.reader_count < usize::MAX && !state.any_writer {
+                state.reader_count += 1;
+                // SAFETY: there are no writers, since any_writers is false
+                return RwLockReadGuard { lock: self };
+            }
+            state.wait_queue.push_back(Waiter {
+                tid: running_thread_tid(),
+                is_writer: false,
+            });
+            drop(state);
+            thread_sleep();
+        }
+    }
+    /// Acquire the lock for writing.
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        loop {
+            let mut state = self.state.lock();
+            if state.reader_count == 0 && !state.any_writer {
+                state.any_writer = true;
+                // SAFETY: there are no readers or writers, according to state.
+                return RwLockWriteGuard { lock: self };
+            }
+            state.wait_queue.push_back(Waiter {
+                tid: running_thread_tid(),
+                is_writer: true,
+            });
+            drop(state);
+            thread_sleep();
+        }
+    }
+    /// Wake up sleeping threads waiting on the lock.
+    fn wakeup(&self) {
+        while let Some(waiter) = self.state.lock().wait_queue.pop_front() {
+            thread_wakeup(waiter.tid);
+            if waiter.is_writer {
+                // no point in waking up more threads since they won't succeed in acquiring the lock
+                break;
+            }
+        }
+    }
+}
+
+unsafe impl<T: Send> Send for RwLock<T> {}
+unsafe impl<T: Send + Sync> Sync for RwLock<T> {}
+
+impl<T> From<T> for RwLock<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        T::default().into()
+    }
+}

--- a/kernel/src/system.rs
+++ b/kernel/src/system.rs
@@ -1,5 +1,5 @@
 use crate::block::block_core::BlockManager;
-use crate::threading::process::{Pid, ProcessState};
+use crate::threading::process::{Pid, ProcessState, Tid};
 use crate::threading::thread_control_block::ProcessControlBlock;
 use crate::threading::ThreadState;
 
@@ -70,4 +70,16 @@ pub fn running_thread_ppid() -> Pid {
     let process_table = unsafe { &unwrap_system().process.table };
     let pcb = process_table.get(tcb.pid).unwrap();
     pcb.ppid
+}
+
+pub fn running_thread_tid() -> Tid {
+    let tcb = unsafe {
+        unwrap_system()
+            .threads
+            .running_thread
+            .as_ref()
+            .expect("Why is nothing running?")
+            .as_ref()
+    };
+    tcb.tid
 }


### PR DESCRIPTION
Add an RwLock structure, similar to `std::sync::RwLock`.
I've tested out this implementation with 10000 threads on my machine and it seems to work fine.

This PR also removes `force_unlock` since clippy was complaining about it and we're not using it anymore (std's mutex doesn't have it so I think it's fine if we don't— forcibly unlocking a mutex is almost always a bad idea...)