### PR TITLE
Accessing SystemState safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "kidneyos-syscalls",
  "lazy_static",
  "nom",
+ "once_cell",
  "zerocopy",
 ]
 
@@ -229,18 +230,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,6 @@ dependencies = [
  "kidneyos-syscalls",
  "lazy_static",
  "nom",
- "once_cell",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,18 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ panic = "abort"
 # debug builds, to speed up tests.
 [profile.dev.package.flate2]
 opt-level = 3
+[profile.dev.package.miniz_oxide]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,3 @@ panic = "abort"
 # debug builds, to speed up tests.
 [profile.dev.package.flate2]
 opt-level = 3
-[profile.dev.package.miniz_oxide]
-opt-level = 3

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -13,6 +13,7 @@ kidneyos-shared.path = "../shared"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 zerocopy = { version = "0.7.35", features = ["derive"] }
 kidneyos-syscalls.path = "../syscalls"
+once_cell = { version = "1.20.2", default-features = false, features = ["race", "alloc"] }
 
 [features]
 default = ["ticket_mutex"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -13,7 +13,6 @@ kidneyos-shared.path = "../shared"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 zerocopy = { version = "0.7.35", features = ["derive"] }
 kidneyos-syscalls.path = "../syscalls"
-once_cell = { version = "1.20.2", default-features = false, features = ["race", "alloc"] }
 
 [features]
 default = ["ticket_mutex"]

--- a/kernel/src/block/block_core.rs
+++ b/kernel/src/block/block_core.rs
@@ -294,12 +294,12 @@ pub mod test {
             index: 0,
             block_name: "<test file>".into(),
             block_type: BlockType::FileSystem,
-            driver: Box::new(FileBlockOps(file)),
+            driver: Mutex::new(Box::new(FileBlockOps(file))),
             block_size: (size / BLOCK_SECTOR_SIZE as u64)
                 .try_into()
                 .expect("file too large"),
-            read_count: 0,
-            write_count: 0,
+            read_count: 0.into(),
+            write_count: 0.into(),
         }
     }
 }

--- a/kernel/src/drivers/ata/ata_core.rs
+++ b/kernel/src/drivers/ata/ata_core.rs
@@ -10,7 +10,7 @@ use crate::drivers::ata::ata_channel::AtaChannel;
 use crate::drivers::ata::ata_device::AtaDevice;
 use crate::interrupts::{intr_get_level, IntrLevel};
 use crate::sync::mutex::sleep::SleepMutex;
-use crate::system::unwrap_system_mut;
+use crate::system::unwrap_system;
 use alloc::boxed::Box;
 use alloc::string::String;
 use kidneyos_shared::println;
@@ -120,14 +120,14 @@ unsafe fn identify_ata_device(c: &SleepMutex<AtaChannel>, dev_no: u8, block: boo
         capacity >> 11
     );
 
-    let block_manager = &mut unwrap_system_mut().block_manager;
+    let block_manager = &unwrap_system().block_manager;
 
-    let idx = block_manager.register_block(
+    let idx = block_manager.write().register_block(
         BlockType::Raw,
         &name,
         capacity as BlockSector,
         Box::new(AtaDevice(dev_no)),
     );
 
-    partition_scan(block_manager.by_id(idx).unwrap());
+    partition_scan(block_manager.read().by_id(idx).unwrap().as_ref());
 }

--- a/kernel/src/fs/fs_manager.rs
+++ b/kernel/src/fs/fs_manager.rs
@@ -1,5 +1,4 @@
 use crate::fs::{FileDescriptor, ProcessFileDescriptor};
-use crate::sync::mutex::Mutex;
 use crate::system::unwrap_system;
 use crate::threading::{process::Pid, thread_control_block::ProcessControlBlock};
 use crate::user_program::syscall::Dirent;
@@ -1194,8 +1193,6 @@ impl RootFileSystem {
         }
     }
 }
-
-pub static ROOT: Mutex<RootFileSystem> = Mutex::new(RootFileSystem::new());
 
 #[cfg(test)]
 mod test {

--- a/kernel/src/fs/fs_manager.rs
+++ b/kernel/src/fs/fs_manager.rs
@@ -1187,7 +1187,8 @@ impl RootFileSystem {
             let _ = self.close(ProcessFileDescriptor { pid, fd });
         }
         // decrement reference count to cwd
-        if let Some(pcb) = unsafe { unwrap_system() }.process.table.get(pid) {
+        if let Some(pcb) = unwrap_system().process.table.get(pid) {
+            let pcb = pcb.lock();
             let (cwd_fs, cwd_inode) = pcb.cwd;
             self.file_systems.get_mut(cwd_fs).dec_ref(cwd_inode);
         }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -2,7 +2,7 @@ pub mod fat;
 pub mod fs_manager;
 pub mod syscalls;
 use crate::fs::fs_manager::Mode;
-use crate::system::{running_process, running_thread_pid};
+use crate::system::{root_filesystem, running_process, running_thread_pid};
 use crate::threading::process::Pid;
 use crate::vfs::{Path, Result};
 use alloc::{vec, vec::Vec};
@@ -17,7 +17,7 @@ pub struct ProcessFileDescriptor {
 
 /// Read entire contents of file to kernel memory.
 pub fn read_file(path: &Path) -> Result<Vec<u8>> {
-    let mut root = fs_manager::ROOT.lock();
+    let mut root = root_filesystem().lock();
     let fd = root.open(&running_process().lock(), path, Mode::ReadWrite)?;
     let fd = ProcessFileDescriptor {
         fd,

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -2,7 +2,7 @@ pub mod fat;
 pub mod fs_manager;
 pub mod syscalls;
 use crate::fs::fs_manager::Mode;
-use crate::system::running_process;
+use crate::system::{running_process, running_thread_pid};
 use crate::threading::process::Pid;
 use crate::vfs::{Path, Result};
 use alloc::{vec, vec::Vec};
@@ -17,12 +17,11 @@ pub struct ProcessFileDescriptor {
 
 /// Read entire contents of file to kernel memory.
 pub fn read_file(path: &Path) -> Result<Vec<u8>> {
-    let process = unsafe { running_process() };
     let mut root = fs_manager::ROOT.lock();
-    let fd = root.open(process, path, Mode::ReadWrite)?;
+    let fd = root.open(&running_process().lock(), path, Mode::ReadWrite)?;
     let fd = ProcessFileDescriptor {
         fd,
-        pid: process.pid,
+        pid: running_thread_pid(),
     };
     let mut data = vec![];
     loop {

--- a/kernel/src/sync/mutex/sleep.rs
+++ b/kernel/src/sync/mutex/sleep.rs
@@ -1,4 +1,5 @@
 use crate::interrupts::mutex_irq::MutexIrq;
+use crate::interrupts::{intr_get_level, IntrLevel};
 use crate::system::running_thread_tid;
 use crate::threading::process::{AtomicTid, Tid};
 use crate::threading::thread_sleep::{thread_sleep, thread_wakeup};
@@ -125,6 +126,11 @@ impl<T: ?Sized> SleepMutex<T> {
                 wait_queue.push_back(current_tid);
             }
             drop(wait_queue);
+            debug_assert_eq!(
+                intr_get_level(),
+                IntrLevel::IntrOn,
+                "Trying to lock locked SleepMutex with interrupts off"
+            );
             thread_sleep();
         }
 

--- a/kernel/src/system.rs
+++ b/kernel/src/system.rs
@@ -1,85 +1,66 @@
 use crate::block::block_core::BlockManager;
+use crate::sync::mutex::Mutex;
+use crate::sync::rwlock::sleep::RwLock;
 use crate::threading::process::{Pid, ProcessState, Tid};
 use crate::threading::thread_control_block::ProcessControlBlock;
 use crate::threading::ThreadState;
+use alloc::sync::Arc;
+use once_cell::race::OnceBox;
 
-// Synchronizing this primitive in a safe way is hard.
 pub struct SystemState {
     pub threads: ThreadState,
     pub process: ProcessState,
 
-    pub block_manager: BlockManager,
+    pub block_manager: RwLock<BlockManager>,
 }
 
-pub static mut SYSTEM: Option<SystemState> = None;
-
-// SAFETY: SYSTEM references cannot be accessed simultaneously on different threads.
-#[allow(dead_code)]
-pub unsafe fn unwrap_system() -> &'static SystemState {
-    SYSTEM.as_ref().expect("System not initialized.")
+impl core::fmt::Debug for SystemState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // probably isn't very helpful to show all the fields here.
+        write!(f, "<SystemState>")
+    }
 }
 
-// SAFETY: SYSTEM references cannot be accessed simultaneously on different threads.
-pub unsafe fn unwrap_system_mut() -> &'static mut SystemState {
-    SYSTEM.as_mut().expect("System not initialized.")
+/*
+    We have to put SystemState in a Box because OnceCell can only be used with
+    std or critical-section (which doesn't seem to work).
+    (There's no spinlock version of OnceCell, because of fears about
+    priority inversion, which is irrelevant for us.)
+*/
+static SYSTEM: OnceBox<SystemState> = OnceBox::new();
+
+pub fn init_system(state: SystemState) {
+    SYSTEM
+        .set(alloc::boxed::Box::new(state))
+        .expect("System initialized twice");
+}
+
+pub fn unwrap_system() -> &'static SystemState {
+    SYSTEM.get().expect("System not initialized.")
 }
 
 /// Get reference to running process (panicks if no process is running)
-///
-/// # Safety
-///
-/// SYSTEM/process references cannot be accessed simultaneously on different threads.
-pub unsafe fn running_process() -> &'static ProcessControlBlock {
+pub fn running_process() -> Arc<Mutex<ProcessControlBlock>> {
     let system = unwrap_system();
-    let pid = system.threads.running_thread.as_ref().unwrap().pid;
+    let pid = system.threads.running_thread.lock().as_ref().unwrap().pid;
     system.process.table.get(pid).unwrap()
 }
 
-/// Get mutable reference to running process (panicks if no process is running)
-///
-/// # Safety
-///
-/// SYSTEM/process references cannot be accessed simultaneously on different threads.
-pub unsafe fn running_process_mut() -> &'static mut ProcessControlBlock {
-    let system = unwrap_system_mut();
-    let pid = system.threads.running_thread.as_ref().unwrap().pid;
-    system.process.table.get_mut(pid).unwrap()
-}
-
 pub fn running_thread_pid() -> Pid {
-    let tcb = unsafe {
-        unwrap_system()
-            .threads
-            .running_thread
-            .as_ref()
-            .expect("Why is nothing running?")
-            .as_ref()
-    };
-    tcb.pid
+    let tcb = unwrap_system().threads.running_thread.lock();
+    tcb.as_ref().expect("Why is nothing running?").as_ref().pid
 }
 
 pub fn running_thread_ppid() -> Pid {
-    let tcb = unsafe {
-        unwrap_system()
-            .threads
-            .running_thread
-            .as_ref()
-            .expect("Why is nothing running?")
-            .as_ref()
-    };
-    let process_table = unsafe { &unwrap_system().process.table };
-    let pcb = process_table.get(tcb.pid).unwrap();
-    pcb.ppid
+    running_process().lock().ppid
 }
 
 pub fn running_thread_tid() -> Tid {
-    let tcb = unsafe {
-        unwrap_system()
-            .threads
-            .running_thread
-            .as_ref()
-            .expect("Why is nothing running?")
-            .as_ref()
-    };
-    tcb.tid
+    unwrap_system()
+        .threads
+        .running_thread
+        .lock()
+        .as_ref()
+        .expect("no running thread")
+        .tid
 }

--- a/kernel/src/threading/context_switch.rs
+++ b/kernel/src/threading/context_switch.rs
@@ -2,7 +2,7 @@ use crate::interrupts::{intr_get_level, IntrLevel};
 use core::mem::offset_of;
 
 use super::thread_control_block::{ThreadControlBlock, ThreadStatus};
-use crate::system::unwrap_system_mut;
+use crate::system::unwrap_system;
 use alloc::boxed::Box;
 
 /// Public facing method to perform a context switch between two threads.
@@ -13,13 +13,13 @@ pub unsafe fn switch_threads(
     status_for_current_thread: ThreadStatus,
     switch_to: Box<ThreadControlBlock>,
 ) {
-    let threads = &mut unwrap_system_mut().threads;
-
     assert_eq!(intr_get_level(), IntrLevel::IntrOff);
+    let threads = &unwrap_system().threads;
 
     let switch_from = Box::into_raw(
         threads
             .running_thread
+            .lock()
             .take()
             .expect("Why is nothing running!?"),
     );
@@ -51,7 +51,7 @@ pub unsafe fn switch_threads(
     (*switch_from).status = ThreadStatus::Running;
 
     // After threads have switched, we must update the scheduler and running thread.
-    threads.running_thread = Some(Box::from_raw(switch_from));
+    *threads.running_thread.lock() = Some(Box::from_raw(switch_from));
 
     if previous.status == ThreadStatus::Dying {
         previous.reap();
@@ -59,9 +59,15 @@ pub unsafe fn switch_threads(
         // Page manager must be loaded when dropped.
         previous.page_manager.load();
         drop(previous);
-        threads.running_thread.as_ref().unwrap().page_manager.load();
+        threads
+            .running_thread
+            .lock()
+            .as_ref()
+            .unwrap()
+            .page_manager
+            .load();
     } else {
-        threads.scheduler.push(previous);
+        threads.scheduler.lock().push(previous);
     }
 }
 

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -5,7 +5,8 @@ pub mod thread_control_block;
 pub mod thread_functions;
 pub mod thread_sleep;
 
-use crate::system::unwrap_system_mut;
+use crate::sync::mutex::Mutex;
+use crate::system::unwrap_system;
 use crate::threading::scheduling::Scheduler;
 use crate::user_program::elf::Elf;
 use crate::{
@@ -17,20 +18,20 @@ use alloc::boxed::Box;
 use thread_control_block::ThreadControlBlock;
 
 pub struct ThreadState {
-    pub running_thread: Option<Box<ThreadControlBlock>>,
-    pub scheduler: Box<dyn Scheduler>,
+    pub running_thread: Mutex<Option<Box<ThreadControlBlock>>>,
+    pub scheduler: Mutex<Box<dyn Send + Scheduler>>,
 }
 
 pub fn create_thread_state() -> ThreadState {
     assert_eq!(intr_get_level(), IntrLevel::IntrOff);
 
     // Initialize the scheduler.
-    let scheduler = create_scheduler();
+    let scheduler = Mutex::new(create_scheduler());
 
     // SAFETY: Interrupts must be disabled.
 
     ThreadState {
-        running_thread: None, // Drop Option<> and set this to the IDLE thread?
+        running_thread: Mutex::new(None), // Drop Option<> and set this to the IDLE thread?
         scheduler,
     }
 }
@@ -39,29 +40,23 @@ pub fn create_thread_state() -> ThreadState {
 pub fn thread_system_start(kernel_page_manager: PageManager, init_elf: &[u8]) -> ! {
     assert_eq!(intr_get_level(), IntrLevel::IntrOff);
 
-    unsafe {
-        // Acquiring mutable reference to system here...
-        // ... so we can discard it before we enable interrupts.
-        let system = unwrap_system_mut();
+    let system = unwrap_system();
 
-        // We must 'turn the kernel thread into a thread'.
-        // This amounts to just making a TCB that will be in control of the kernel stack and will
-        // never exit.
-        // This thread also does not need to enter the `run_thread` function.
-        // SAFETY: The kernel thread's stack will be set up by the context switch following.
-        // SAFETY: The kernel thread is allocated a "fake" PCB with pid 0.
-        let kernel_tcb =
-            ThreadControlBlock::new_kernel_thread(kernel_page_manager, &mut system.process);
+    // We must 'turn the kernel thread into a thread'.
+    // This amounts to just making a TCB that will be in control of the kernel stack and will
+    // never exit.
+    // This thread also does not need to enter the `run_thread` function.
+    // SAFETY: The kernel thread's stack will be set up by the context switch following.
+    // SAFETY: The kernel thread is allocated a "fake" PCB with pid 0.
+    let kernel_tcb = ThreadControlBlock::new_kernel_thread(kernel_page_manager, &system.process);
 
-        let elf = Elf::parse_bytes(init_elf).expect("failed to parse provided elf file");
+    let elf = Elf::parse_bytes(init_elf).expect("failed to parse provided elf file");
 
-        // Create the initial user program thread.
-        let user_tcb = ThreadControlBlock::new_from_elf(elf, &mut system.process);
+    // Create the initial user program thread.
+    let user_tcb = ThreadControlBlock::new_from_elf(elf, &system.process);
 
-        // SAFETY: Interrupts must be disabled.
-        system.threads.running_thread = Some(Box::new(kernel_tcb));
-        system.threads.scheduler.push(Box::new(user_tcb));
-    }
+    *system.threads.running_thread.lock() = Some(Box::new(kernel_tcb));
+    system.threads.scheduler.lock().push(Box::new(user_tcb));
 
     intr_enable();
 

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -9,7 +9,6 @@ use crate::{
     vfs::{INodeNum, OwnedPath},
     KERNEL_ALLOCATOR,
 };
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::{
     mem::size_of,
@@ -53,7 +52,7 @@ pub struct ProcessControlBlock {
 }
 
 impl ProcessControlBlock {
-    pub fn create(state: &mut ProcessState, parent_pid: Pid) -> Pid {
+    pub fn create(state: &ProcessState, parent_pid: Pid) -> Pid {
         let pid = state.allocate_pid();
         let mut root = crate::fs::fs_manager::ROOT.lock();
         // open stdin, stdout, stderr
@@ -68,7 +67,7 @@ impl ProcessControlBlock {
             cwd_path: "/".into(),
         };
 
-        state.table.add(Box::new(pcb));
+        state.table.add(pcb);
 
         pid
     }
@@ -99,7 +98,7 @@ pub struct ThreadControlBlock {
 }
 
 impl ThreadControlBlock {
-    pub fn new_from_elf(elf: Elf, state: &mut ProcessState) -> ThreadControlBlock {
+    pub fn new_from_elf(elf: Elf, state: &ProcessState) -> ThreadControlBlock {
         // Shared ELFs can count as a "Relocatable Executable" if the entry point is set.
         let executable = matches!(elf.header.usage, ElfUsage::Executable | ElfUsage::Shared);
 
@@ -107,14 +106,13 @@ impl ThreadControlBlock {
             panic!("ELF was valid, but it was not an executable or it did not target the host platform (x86)");
         }
 
-        let ppid = unsafe {
-            unwrap_system()
-                .threads
-                .running_thread
-                .as_ref()
-                .map_or(0, |_| running_thread_ppid())
+        let running_thread = unwrap_system().threads.running_thread.lock();
+        let ppid = if running_thread.is_none() {
+            0
+        } else {
+            drop(running_thread);
+            running_thread_ppid()
         };
-
         let pid: Pid = ProcessControlBlock::create(state, ppid);
 
         let mut page_manager = PageManager::default();
@@ -190,7 +188,7 @@ impl ThreadControlBlock {
         entry_instruction: NonNull<u8>,
         pid: Pid,
         page_manager: PageManager,
-        state: &mut ProcessState,
+        state: &ProcessState,
     ) -> Self {
         let mut new_thread = Self::new(entry_instruction, pid, page_manager, state);
 
@@ -247,7 +245,7 @@ impl ThreadControlBlock {
         entry_instruction: NonNull<u8>,
         pid: Pid,
         mut page_manager: PageManager,
-        state: &mut ProcessState,
+        state: &ProcessState,
     ) -> Self {
         let tid: Tid = state.allocate_tid();
 
@@ -309,7 +307,7 @@ impl ThreadControlBlock {
     ///
     /// # Safety
     /// Should only be used once while starting the threading system.
-    pub fn new_kernel_thread(page_manager: PageManager, state: &mut ProcessState) -> Self {
+    pub fn new_kernel_thread(page_manager: PageManager, state: &ProcessState) -> Self {
         ThreadControlBlock {
             kernel_stack_pointer: NonNull::dangling(), // This will be set in the context switch immediately following.
             kernel_stack: NonNull::dangling(),
@@ -380,3 +378,5 @@ impl ThreadControlBlock {
         self.status = ThreadStatus::Invalid;
     }
 }
+
+unsafe impl Send for ThreadControlBlock {}

--- a/kernel/src/threading/thread_sleep.rs
+++ b/kernel/src/threading/thread_sleep.rs
@@ -1,5 +1,5 @@
 use super::{scheduling::scheduler_yield_and_block, thread_control_block::ThreadStatus};
-use crate::system::unwrap_system_mut;
+use crate::system::unwrap_system;
 use crate::threading::process::Tid;
 
 pub fn thread_sleep() {
@@ -7,8 +7,8 @@ pub fn thread_sleep() {
 }
 
 pub fn thread_wakeup(tid: Tid) {
-    let threads = unsafe { &mut unwrap_system_mut().threads };
-    if let Some(tcb) = threads.scheduler.get_mut(tid) {
+    let threads = &unwrap_system().threads;
+    if let Some(tcb) = threads.scheduler.lock().get_mut(tid) {
         tcb.status = ThreadStatus::Ready;
     }
 }

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -6,7 +6,7 @@ use crate::fs::syscalls::{
 };
 use crate::mem::user::check_and_copy_user_memory;
 use crate::mem::util::get_mut_from_user_space;
-use crate::system::{running_thread_pid, running_thread_ppid, unwrap_system_mut};
+use crate::system::{running_thread_pid, running_thread_ppid, unwrap_system};
 use crate::threading::scheduling::{scheduler_yield_and_continue, scheduler_yield_and_die};
 use crate::threading::thread_control_block::ThreadControlBlock;
 use crate::threading::thread_functions;
@@ -36,7 +36,7 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
         SYS_READ => unsafe { read(arg0, arg1 as _, arg2 as _) },
         SYS_WRITE => unsafe { write(arg0, arg1 as _, arg2 as _) },
         SYS_LSEEK64 => unsafe { lseek64(arg0, arg1 as _, arg2 as _) },
-        SYS_CLOSE => unsafe { close(arg0) },
+        SYS_CLOSE => close(arg0),
         SYS_CHDIR => unsafe { chdir(arg0 as _) },
         SYS_GETCWD => unsafe { getcwd(arg0 as _, arg1 as _) },
         SYS_MKDIR => unsafe { mkdir(arg0 as _) },
@@ -47,7 +47,7 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
         SYS_LINK => unsafe { link(arg0 as _, arg1 as _) },
         SYS_SYMLINK => unsafe { symlink(arg0 as _, arg1 as _) },
         SYS_RENAME => unsafe { rename(arg0 as _, arg1 as _) },
-        SYS_FTRUNCATE => unsafe { ftruncate(arg0 as _, arg1 as _, arg2 as _) },
+        SYS_FTRUNCATE => ftruncate(arg0 as _, arg1 as _, arg2 as _),
         SYS_UNMOUNT => unsafe { unmount(arg0 as _) },
         SYS_MOUNT => unsafe { mount(arg0 as _, arg1 as _, arg2 as _) },
         SYS_SYNC => sync(),
@@ -55,30 +55,22 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
             todo!("waitpid syscall")
         }
         SYS_EXECVE => {
-            let thread = unsafe {
-                unwrap_system_mut()
-                    .threads
-                    .running_thread
-                    .as_ref()
-                    .expect("A syscall was called without a running thread.")
-            };
-
+            let system = unwrap_system();
+            let guard = system.threads.running_thread.lock();
+            let thread = guard
+                .as_ref()
+                .expect("A syscall was called without a running thread.");
             let elf_bytes = check_and_copy_user_memory(arg0, arg1, &thread.page_manager);
+            drop(guard);
             let elf = elf_bytes
                 .as_ref()
                 .and_then(|bytes| Elf::parse_bytes(bytes).ok());
 
             let Some(elf) = elf else { return -1 };
 
-            let system = unsafe { unwrap_system_mut() };
-            let control = ThreadControlBlock::new_from_elf(elf, &mut system.process);
+            let control = ThreadControlBlock::new_from_elf(elf, &system.process);
 
-            unsafe {
-                unwrap_system_mut()
-                    .threads
-                    .scheduler
-                    .push(Box::new(control));
-            }
+            system.threads.scheduler.lock().push(Box::new(control));
 
             scheduler_yield_and_die();
         }

--- a/shared/src/mem/mod.rs
+++ b/shared/src/mem/mod.rs
@@ -70,7 +70,7 @@ pub mod virt {
 pub const OFFSET: usize = 0x80000000;
 
 // TODO: Figure out how to detect kernel stack overflows.
-pub const MAIN_STACK_SIZE: usize = 32 * KB;
+pub const MAIN_STACK_SIZE: usize = 2 * MB;
 pub const TRAMPOLINE_HEAP_SIZE: usize = 8 * MB;
 
 // TODO: We currently leave 8MB for the bootstrap allocator. This should be

--- a/shared/src/paging.rs
+++ b/shared/src/paging.rs
@@ -145,6 +145,7 @@ fn virt_parts(virt_addr: usize) -> (usize, usize) {
 }
 
 /// Wraps lower-level paging data structures.
+#[derive(Debug)]
 pub struct PageManager<A: Allocator> {
     root: NonNull<PageDirectory>,
     alloc: A,


### PR DESCRIPTION
Resolves #87 
With this PR, you can only access SystemState through a shared reference. The members of SystemState have to manage shared access individually.
We still have to use a `static mut` for the SystemState, but it's now private and can only be accessed through safe functions (an atomic variable is used to keep track of whether the systesm is initialized). I wanted to use the `once_cell` crate, but it looks like that needs either std or critical-section, and critical-section wasn't working …

Also I've moved the `RootFileSystem` object to SystemState, now that it can be accessed safely there 
~~(Currently a draft until #100 is merged)~~