### PR TITLE
Register Swap Partition

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+# Prevent accidental commits of disk images.
+if git diff --cached --name-only | grep -q '\.img$'; then
+  echo "WARNING: You are about to commit a disk image."
+  echo "If you are sure you want to do this, use 'git commit --no-verify'."
+  exit 1
+fi
+
 make -f programs.mk
 cargo clippy --target i686-unknown-linux-gnu -- -D warnings
 cargo fmt -- --quiet --check

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RAW_TRAMPOLINE := $(ARTIFACT_DIR)/libkidneyos_trampoline.a
 TRAMPOLINE_DIR := build/trampoline
 TRAMPOLINE := $(TRAMPOLINE_DIR)/libkidneyos_trampoline.a
 ISO := build/kidneyos.iso
-ATADISK := gpt_fat16_50MiB.img
+ATADISK := mbr_ext4_50MiB.img
 
 .PHONY: default
 default: $(ISO)

--- a/kernel/src/block/block_error.rs
+++ b/kernel/src/block/block_error.rs
@@ -4,6 +4,8 @@ use core::fmt::{Debug, Display, Formatter};
 /// Error type for block operations
 #[derive(Debug)]
 pub enum BlockError {
+    /// The requested block device was not found
+    DeviceNotFound,
     /// The sector is out of bounds (greater than the block size)
     SectorOutOfBounds,
     /// The buffer has an invalid size (not `BLOCK_SECTOR_SIZE`)
@@ -23,6 +25,7 @@ impl Display for BlockError {
 impl Error for BlockError {
     fn description(&self) -> &str {
         match self {
+            BlockError::DeviceNotFound => "Block device not found",
             BlockError::SectorOutOfBounds => "Sector out of bounds (greater than the block size)",
             BlockError::BufferInvalid => "Invalid buffer size (not `BLOCK_SECTOR_SIZE`)",
             BlockError::ReadError => "Error reading from the block device",

--- a/kernel/src/block/partitions/mod.rs
+++ b/kernel/src/block/partitions/mod.rs
@@ -1,1 +1,3 @@
 pub mod partition_core;
+pub mod partition_register;
+mod partition_utils;

--- a/kernel/src/block/partitions/partition_core.rs
+++ b/kernel/src/block/partitions/partition_core.rs
@@ -13,24 +13,22 @@ use kidneyos_shared::{eprintln, println};
 /// A partition table entry in the MBR.
 ///
 /// Reference: https://wiki.osdev.org/MBR_(x86)#Partition_table_entry_format
-///
-/// Note: The CHS addresses, offset, and size use LITTLE ENDIAN
 pub(crate) struct PartitionTableEntry {
     /// 0x00    1   Drive attributes (bit 7 set = active or bootable)
     bootable: u8,
 
     /// 0x01    3   CHS Address of partition start
+    start_cylinder: u8,
     start_head: u8,
     start_sector: u8,
-    start_cylinder: u8,
 
     /// 0x04    1   Partition type
     partition_type: u8,
 
     /// 0x05    3   CHS address of last partition sector
+    end_cylinder: u8,
     end_head: u8,
     end_sector: u8,
-    end_cylinder: u8,
 
     /// 0x08    4   LBA of partition start
     offset: u32,
@@ -246,13 +244,13 @@ impl fmt::Display for PartitionTableEntry {
 impl PartitionTableEntry {
     pub(crate) fn new(buf: &[u8]) -> PartitionTableEntry {
         let bootable = buf[0];
-        let start_head = buf[1];
-        let start_sector = buf[2];
-        let start_cylinder = buf[3];
+        let start_cylinder = buf[1];
+        let start_head = buf[2];
+        let start_sector = buf[3];
         let partition_type = buf[4];
-        let end_head = buf[5];
-        let end_sector = buf[6];
-        let end_cylinder = buf[7];
+        let end_cylinder = buf[5];
+        let end_head = buf[6];
+        let end_sector = buf[7];
         let offset = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         let size = u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
 

--- a/kernel/src/block/partitions/partition_core.rs
+++ b/kernel/src/block/partitions/partition_core.rs
@@ -1,30 +1,36 @@
+#![allow(dead_code)] // Suppress unused warnings, especially for the getters and setters
+
 use crate::block::block_core::{Block, BlockOp, BlockSector, BlockType, BLOCK_SECTOR_SIZE};
 use crate::block::block_error::BlockError;
+use crate::block::partitions::partition_utils::lba_to_chs;
 use crate::interrupts::{intr_disable, intr_enable, intr_get_level, IntrLevel};
 use crate::system::unwrap_system_mut;
 use alloc::boxed::Box;
 use alloc::format;
+use core::fmt;
 use kidneyos_shared::{eprintln, println};
 
 /// A partition table entry in the MBR.
 ///
 /// Reference: https://wiki.osdev.org/MBR_(x86)#Partition_table_entry_format
-struct PartitionTableEntry {
+///
+/// Note: The CHS addresses, offset, and size use LITTLE ENDIAN
+pub(crate) struct PartitionTableEntry {
     /// 0x00    1   Drive attributes (bit 7 set = active or bootable)
-    _bootable: u8,
+    bootable: u8,
 
     /// 0x01    3   CHS Address of partition start
-    _start_cylinder: u8,
-    _start_head: u8,
-    _start_sector: u8,
+    start_head: u8,
+    start_sector: u8,
+    start_cylinder: u8,
 
     /// 0x04    1   Partition type
     partition_type: u8,
 
     /// 0x05    3   CHS address of last partition sector
-    _end_cylinder: u8,
-    _end_head: u8,
-    _end_sector: u8,
+    end_head: u8,
+    end_sector: u8,
+    end_cylinder: u8,
 
     /// 0x08    4   LBA of partition start
     offset: u32,
@@ -32,53 +38,292 @@ struct PartitionTableEntry {
     size: u32,
 }
 
+// Getters and setters
 impl PartitionTableEntry {
-    fn new(buf: &[u8]) -> PartitionTableEntry {
+    /// Get the bootable flag.
+    pub(crate) fn get_bootable(&self) -> u8 {
+        self.bootable
+    }
+
+    /// Set the bootable flag.
+    pub(crate) fn set_bootable(&mut self, bootable: bool) {
+        self.bootable = if bootable { 0x01 } else { 0x00 };
+    }
+
+    /// Get the cylinder of the start CHS address.
+    pub(crate) fn get_start_cylinder(&self) -> u8 {
+        self.start_cylinder
+    }
+
+    /// Set the cylinder of the start CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_start`] instead.
+    pub(crate) fn set_start_cylinder(&mut self, start_cylinder: u8) {
+        self.start_cylinder = start_cylinder;
+    }
+
+    /// Get the head of the start CHS address.
+    pub(crate) fn get_start_head(&self) -> u8 {
+        self.start_head
+    }
+
+    /// Set the head of the start CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_start`] instead.
+    pub(crate) fn set_start_head(&mut self, start_head: u8) {
+        self.start_head = start_head;
+    }
+
+    /// Get the sector of the start CHS address.
+    pub(crate) fn get_start_sector(&self) -> u8 {
+        self.start_sector
+    }
+
+    /// Set the sector of the start CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_start`] instead.
+    pub(crate) fn set_start_sector(&mut self, start_sector: u8) {
+        self.start_sector = start_sector;
+    }
+
+    /// Set the start CHS address and update the offset.
+    ///
+    /// # Safety
+    ///
+    /// After calling this function, either `size` or `end` must be updated to avoid inconsistencies.
+    ///
+    /// # Important
+    ///
+    /// Despite the name, this function also updates the `offset` to avoid inconsistencies. This
+    /// function is mutually exclusive with [`PartitionTableEntry::set_offset`], and it suffices to
+    /// call one of them.
+    pub(crate) unsafe fn set_start(&mut self, start: BlockSector) {
+        let (cylinder, head, sector) = lba_to_chs(start);
+        self.start_cylinder = cylinder;
+        self.start_head = head;
+        self.start_sector = sector;
+
+        // Also update the offset
+        self.offset = start;
+    }
+
+    /// Get the partition type.
+    ///
+    /// The partition type is a number that represents the type of the partition.
+    /// To get the name of the partition type, see the [`partition_type_name`] function.
+    pub(crate) fn get_partition_type(&self) -> u8 {
+        self.partition_type
+    }
+
+    /// Set the partition type.
+    pub(crate) fn set_partition_type(&mut self, partition_type: u8) {
+        self.partition_type = partition_type;
+    }
+
+    /// Get the cylinder of the end CHS address.
+    pub(crate) fn get_end_cylinder(&self) -> u8 {
+        self.end_cylinder
+    }
+
+    /// Set the cylinder of the end CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_end`] instead.
+    pub(crate) fn set_end_cylinder(&mut self, end_cylinder: u8) {
+        self.end_cylinder = end_cylinder;
+    }
+
+    /// Get the head of the end CHS address.
+    pub(crate) fn get_end_head(&self) -> u8 {
+        self.end_head
+    }
+
+    /// Set the head of the end CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_end`] instead.
+    pub(crate) fn set_end_head(&mut self, end_head: u8) {
+        self.end_head = end_head;
+    }
+
+    /// Get the sector of the end CHS address.
+    pub(crate) fn get_end_sector(&self) -> u8 {
+        self.end_sector
+    }
+
+    /// Set the sector of the end CHS address.
+    ///
+    /// Calling this function is discouraged. Use [`PartitionTableEntry::set_end`] instead.
+    pub(crate) fn set_end_sector(&mut self, end_sector: u8) {
+        self.end_sector = end_sector;
+    }
+
+    /// Set the end CHS address and update the size.
+    ///
+    /// # Safety
+    ///
+    /// This function must be called after setting the `offset` to avoid inconsistencies.
+    ///
+    /// # Important
+    ///
+    /// Despite the name, this function also updates the `size` to avoid inconsistencies. This
+    /// function is mutually exclusive with [`PartitionTableEntry::set_size`], and it suffices to
+    /// call one of them.
+    pub(crate) unsafe fn set_end(&mut self, end: BlockSector) {
+        let (cylinder, head, sector) = lba_to_chs(end);
+        self.end_cylinder = cylinder;
+        self.end_head = head;
+        self.end_sector = sector;
+
+        // Also update the size
+        self.size = end - self.offset;
+    }
+
+    /// Get the offset.
+    pub(crate) fn get_offset(&self) -> u32 {
+        self.offset
+    }
+
+    /// Set the offset.
+    ///
+    /// # Safety
+    ///
+    /// After calling this function, either `size` or `end` must be updated to avoid inconsistencies.
+    ///
+    /// # Important
+    ///
+    /// Despite the name, this function also updates the `start` to avoid inconsistencies. This
+    /// function is mutually exclusive with [`PartitionTableEntry::set_start`], and it suffices to
+    /// call one of them.
+    pub(crate) unsafe fn set_offset(&mut self, offset: u32) {
+        self.offset = offset;
+
+        // Also update the start
+        self.set_start(offset);
+    }
+
+    /// Get the size.
+    pub(crate) fn get_size(&self) -> u32 {
+        self.size
+    }
+
+    /// Set the size.
+    ///
+    /// # Safety
+    ///
+    /// This function must be called after setting the `offset` to avoid inconsistencies.
+    ///
+    /// # Important
+    ///
+    /// Despite the name, this function also updates the `end` to avoid inconsistencies. This
+    /// function is mutually exclusive with [`PartitionTableEntry::set_end`], and it suffices to
+    /// call one of them.
+    pub(crate) unsafe fn set_size(&mut self, size: u32) {
+        self.size = size;
+
+        // Also update the end
+        self.set_end(self.offset + size);
+    }
+}
+
+impl fmt::Display for PartitionTableEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "bootable: {}, start: {}:{}:{}, type: {}, end: {}:{}:{}, offset: {}, size: {}",
+            self.bootable,
+            self.start_cylinder,
+            self.start_head,
+            self.start_sector,
+            partition_type_name(self.partition_type),
+            self.end_cylinder,
+            self.end_head,
+            self.end_sector,
+            self.offset,
+            self.size
+        )
+    }
+}
+
+impl PartitionTableEntry {
+    pub(crate) fn new(buf: &[u8]) -> PartitionTableEntry {
         let bootable = buf[0];
-        let start_cylinder = buf[1];
-        let start_head = buf[2];
-        let start_sector = buf[3];
+        let start_head = buf[1];
+        let start_sector = buf[2];
+        let start_cylinder = buf[3];
         let partition_type = buf[4];
-        let end_cylinder = buf[5];
-        let end_head = buf[6];
-        let end_sector = buf[7];
+        let end_head = buf[5];
+        let end_sector = buf[6];
+        let end_cylinder = buf[7];
         let offset = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         let size = u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
 
         PartitionTableEntry {
-            _bootable: bootable,
-            _start_cylinder: start_cylinder,
-            _start_head: start_head,
-            _start_sector: start_sector,
+            bootable,
+            start_cylinder,
+            start_head,
+            start_sector,
             partition_type,
-            _end_cylinder: end_cylinder,
-            _end_head: end_head,
-            _end_sector: end_sector,
+            end_cylinder,
+            end_head,
+            end_sector,
             offset,
             size,
         }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.size == 0 || self.partition_type == 0
+    }
+
+    pub(crate) fn serialize(&self, buf: &mut [u8]) {
+        // Bootable     0       +1      1
+        buf[0] = self.bootable;
+
+        // Start        1       +3      4
+        // Cylinder     1       +1      2
+        buf[1] = self.start_cylinder;
+        // Head         2       +1      3
+        buf[2] = self.start_head;
+        // Sector       3       +1      4
+        buf[3] = self.start_sector;
+
+        // Type         4       +1      5
+        buf[4] = self.partition_type;
+
+        // End          5       +3      8
+        // Cylinder     5       +1      6
+        buf[5] = self.end_cylinder;
+        // Head         6       +1      7
+        buf[6] = self.end_head;
+        // Sector       7       +1      8
+        buf[7] = self.end_sector;
+
+        // Offset       8       +4      12
+        buf[8..12].copy_from_slice(&self.offset.to_le_bytes());
+
+        // Size         12      +4      16
+        buf[12..16].copy_from_slice(&self.size.to_le_bytes());
     }
 }
 
 /// An MBR partition table.
 ///
 /// Reference: https://wiki.osdev.org/MBR_(x86)#MBR_format
-struct PartitionTable {
+pub(crate) struct PartitionTable {
     /// 0x000   440     MBR Bootstrap (flat binary executable code)
     ///
     /// This can be extended to 446 bytes if you omit the next 2 optional fields: Disk ID and
     /// reserved.
-    pub _bootstrap: [u8; 440],
+    pub bootstrap: [u8; 440],
     /// 0x1B8   4       Optional "Unique Disk ID / Signature"
     ///
     /// The 4 byte "Unique Disk ID" is used by recent Linux and Windows systems to identify the
     /// drive. "Unique" in this case means that the IDs of all the drives attached to a particular system are distinct.
-    pub _id: u32,
+    pub id: u32,
     /// 0x1BC   2       Optional, reserved 0x0000
     ///
     /// The 2 byte reserved is usually 0x0000. 0x5A5A means read-only according to
     /// https://neosmart.net/wiki/mbr-boot-process/
-    pub _reserved: u16,
+    pub reserved: u16,
 
     /// 0x1BE   16      First partition table entry
     /// 0x1CE   16      Second partition table entry
@@ -90,7 +335,7 @@ struct PartitionTable {
 }
 
 impl PartitionTable {
-    fn new(buf: &[u8]) -> PartitionTable {
+    pub(crate) fn new(buf: &[u8]) -> PartitionTable {
         let mut bootstrap = [0; 440];
         bootstrap.copy_from_slice(&buf[0..440]);
         let id = u32::from_le_bytes([buf[440], buf[441], buf[442], buf[443]]);
@@ -104,17 +349,46 @@ impl PartitionTable {
         let signature = u16::from_le_bytes([buf[510], buf[511]]);
 
         PartitionTable {
-            _bootstrap: bootstrap,
-            _id: id,
-            _reserved: reserved,
+            bootstrap,
+            id,
+            reserved,
             entries,
             signature,
         }
     }
+
+    pub(crate) fn serialize(&self, buf: &mut [u8]) {
+        // Bootstrap    0       +440    440
+        buf[0..440].copy_from_slice(&self.bootstrap);
+
+        // Id           440     +4      444
+        buf[440..444].copy_from_slice(&self.id.to_le_bytes());
+
+        // Reserved     444     +2      446
+        buf[444..446].copy_from_slice(&self.reserved.to_le_bytes());
+
+        // Entries      446     +64     510
+        let mut entry_buf: [u8; 16] = [0; 16];
+        // Entry 1      446     +16     462
+        self.entries[0].serialize(&mut entry_buf);
+        buf[446..462].copy_from_slice(&entry_buf);
+        // Entry 2      462     +16     478
+        self.entries[1].serialize(&mut entry_buf);
+        buf[462..478].copy_from_slice(&entry_buf);
+        // Entry 3      478     +16     494
+        self.entries[2].serialize(&mut entry_buf);
+        buf[478..494].copy_from_slice(&entry_buf);
+        // Entry 4      494     +16     510
+        self.entries[3].serialize(&mut entry_buf);
+        buf[494..510].copy_from_slice(&entry_buf);
+
+        // Signature    510     +2      512
+        buf[510..512].copy_from_slice(&self.signature.to_le_bytes());
+    }
 }
 
 /// A partition.
-struct Partition {
+pub struct Partition {
     block_idx: usize,
     start: BlockSector,
 }

--- a/kernel/src/block/partitions/partition_register.rs
+++ b/kernel/src/block/partitions/partition_register.rs
@@ -1,0 +1,71 @@
+#![allow(dead_code)] // Suppress unused warnings
+
+use crate::block::block_core::{Block, BlockSector, BlockType, BLOCK_SECTOR_SIZE};
+use crate::block::block_error::BlockError;
+use crate::block::partitions::partition_core::PartitionTable;
+use crate::system::unwrap_system_mut;
+use kidneyos_shared::eprintln;
+
+/// Register a partition on a block device.
+///
+/// # Safety
+///
+/// This function does not check for partition overlaps or other issues. It is up to the caller to
+/// ensure that the partition is valid. For example, this function does not panic if we try to
+/// register a partition that overlaps with an existing partition.
+pub unsafe fn register_partition(
+    p_start: BlockSector,
+    p_size: BlockSector,
+    p_type: BlockType,
+    device: usize,
+) -> Result<(), BlockError> {
+    let block_manager = unsafe { &mut unwrap_system_mut().block_manager };
+    let block_device = block_manager
+        .by_id(device)
+        .ok_or(BlockError::DeviceNotFound)?;
+
+    if p_start + p_size > block_device.get_size() {
+        return Err(BlockError::SectorOutOfBounds);
+    }
+
+    if p_type == BlockType::Swap {
+        register_swap_partition(p_start, p_size, block_device)
+    } else {
+        panic!("Registering partition of type {} not supported", p_type);
+    }
+}
+
+fn register_swap_partition(
+    p_start: BlockSector,
+    p_size: BlockSector,
+    device: &mut Block,
+) -> Result<(), BlockError> {
+    let mut buf: [u8; BLOCK_SECTOR_SIZE] = [0; BLOCK_SECTOR_SIZE];
+
+    device.read(0, &mut buf)?;
+
+    let mut pt = PartitionTable::new(&buf);
+    let empty_entry = pt.entries.iter_mut().find(|e| e.is_empty());
+
+    if empty_entry.is_none() {
+        eprintln!("No empty partition entries found");
+        return Err(BlockError::WriteError);
+    }
+
+    let entry = empty_entry.unwrap();
+    // Bootable     0       +1      1
+    entry.set_bootable(false);
+    // Start        1       +3      4
+    unsafe { entry.set_start(p_start) };
+    // Type         4       +1      5       0x82: Linux Swap
+    entry.set_partition_type(0x82);
+    // End          5       +3      8       (set by set_size)
+    // Offset       8       +4      12      (set by set_start)
+    // Size         12      +4      16
+    unsafe { entry.set_size(p_size) };
+
+    // Write the partition table back to the disk
+    buf = [0; BLOCK_SECTOR_SIZE]; // Clear the buffer, just in case
+    pt.serialize(&mut buf);
+    device.write(0, &buf)
+}

--- a/kernel/src/block/partitions/partition_utils.rs
+++ b/kernel/src/block/partitions/partition_utils.rs
@@ -1,0 +1,76 @@
+#![allow(dead_code)] // Suppress unused warnings
+
+use crate::block::block_core::BlockSector;
+
+/// Converts a CHS address to an LBA address.
+///
+/// # Arguments
+/// * `cylinder` - The cylinder number.
+/// * `head` - The head number.
+/// * `sector` - The sector number.
+pub(crate) fn chs_to_lba(cylinder: u8, head: u8, sector: u8) -> BlockSector {
+    (cylinder as u32 * 16 + head as u32) * 63 + sector as u32 - 1
+}
+
+/// Converts an LBA address to a CHS address.
+///
+/// # Arguments
+/// * `lba` - The LBA address.
+pub(crate) fn lba_to_chs(lba: BlockSector) -> (u8, u8, u8) {
+    let sector = lba % 63 + 1;
+    let temp = lba / 63;
+    let head = temp % 16;
+    let cylinder = temp / 16;
+
+    (cylinder as u8, head as u8, sector as u8)
+}
+
+#[test]
+fn test_chs_to_lba() {
+    // Values taken from:
+    // https://en.wikipedia.org/wiki/Logical_block_addressing#CHS_conversion
+
+    assert_eq!(chs_to_lba(0, 0, 1), 0);
+    assert_eq!(chs_to_lba(0, 0, 2), 1);
+    assert_eq!(chs_to_lba(0, 0, 3), 2);
+    assert_eq!(chs_to_lba(0, 0, 63), 62);
+    assert_eq!(chs_to_lba(0, 1, 1), 63);
+    assert_eq!(chs_to_lba(0, 15, 1), 945);
+    assert_eq!(chs_to_lba(0, 15, 63), 1007);
+    assert_eq!(chs_to_lba(1, 0, 1), 1008);
+    assert_eq!(chs_to_lba(1, 0, 63), 1070);
+    assert_eq!(chs_to_lba(1, 1, 1), 1071);
+    assert_eq!(chs_to_lba(1, 1, 63), 1133);
+    assert_eq!(chs_to_lba(1, 2, 1), 1134);
+    assert_eq!(chs_to_lba(1, 15, 63), 2015);
+    assert_eq!(chs_to_lba(2, 0, 1), 2016);
+    assert_eq!(chs_to_lba(15, 15, 63), 16127);
+    assert_eq!(chs_to_lba(16, 0, 1), 16128);
+    assert_eq!(chs_to_lba(31, 15, 63), 32255);
+    assert_eq!(chs_to_lba(32, 0, 1), 32256);
+}
+
+#[test]
+fn test_lba_to_chs() {
+    // Values taken from:
+    // https://en.wikipedia.org/wiki/Logical_block_addressing#CHS_conversion
+
+    assert_eq!(lba_to_chs(0), (0, 0, 1));
+    assert_eq!(lba_to_chs(1), (0, 0, 2));
+    assert_eq!(lba_to_chs(2), (0, 0, 3));
+    assert_eq!(lba_to_chs(62), (0, 0, 63));
+    assert_eq!(lba_to_chs(63), (0, 1, 1));
+    assert_eq!(lba_to_chs(945), (0, 15, 1));
+    assert_eq!(lba_to_chs(1007), (0, 15, 63));
+    assert_eq!(lba_to_chs(1008), (1, 0, 1));
+    assert_eq!(lba_to_chs(1070), (1, 0, 63));
+    assert_eq!(lba_to_chs(1071), (1, 1, 1));
+    assert_eq!(lba_to_chs(1133), (1, 1, 63));
+    assert_eq!(lba_to_chs(1134), (1, 2, 1));
+    assert_eq!(lba_to_chs(2015), (1, 15, 63));
+    assert_eq!(lba_to_chs(2016), (2, 0, 1));
+    assert_eq!(lba_to_chs(16127), (15, 15, 63));
+    assert_eq!(lba_to_chs(16128), (16, 0, 1));
+    assert_eq!(lba_to_chs(32255), (31, 15, 63));
+    assert_eq!(lba_to_chs(32256), (32, 0, 1));
+}


### PR DESCRIPTION
The new disk image contains a swap partition from sector 2048 to 10240 (8192 sectors).

To mount/unmount the ext4 partition
```sh
cd KidneyOS

# start at 10240 sector, with sector size of 512
sudo losetup -o $[10240*512] /dev/loop0 mbr_ext4_50MiB.img
sudo losetup -a
# /dev/loop0: ... (.../KidneyOS/mbr_ext4_50MiB.img), offset 5242880
sudo mount /dev/loop0 /mnt/sub/dir

# unmount
sudo umount /dev/loop0
sudo losetup -d /dev/loop0
sudo losetup -a  # should report nothing
```