### PR TITLE
Keyboard support

### DIFF
--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -1,2 +1,3 @@
 pub mod ata;
 pub mod dummy_device;
+pub mod ps_2;

--- a/kernel/src/drivers/ps_2/input.rs
+++ b/kernel/src/drivers/ps_2/input.rs
@@ -1,0 +1,59 @@
+use core::fmt::Display;
+
+const BUFFER_SIZE: usize = 256;
+
+/// A circular buffer for storing input from the PS/2 controller.
+pub struct InputBuffer {
+    // TODO: CV for not full and not empty?
+    /// The buffer itself.
+    buf: [u8; BUFFER_SIZE],
+    /// The index of the head of the buffer.
+    head: usize,
+    /// The index of the tail of the buffer.
+    tail: usize,
+}
+
+#[allow(unused)]
+impl InputBuffer {
+    /// Create a new, empty input buffer.
+    pub const fn new() -> InputBuffer {
+        InputBuffer {
+            buf: [0; BUFFER_SIZE],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.head == self.tail
+    }
+
+    /// Add a byte to the buffer.
+    pub fn putc(&mut self, c: u8) {
+        // TODO: wait while buffer is full
+
+        self.buf[self.head] = c;
+        self.head = (self.head + 1) % BUFFER_SIZE;
+    }
+
+    /// Get a byte from the buffer.
+    pub fn getc(&mut self) -> Option<u8> {
+        if self.head == self.tail {
+            None
+        } else {
+            let c = self.buf[self.tail];
+            self.tail = (self.tail + 1) % BUFFER_SIZE;
+            Some(c)
+        }
+    }
+}
+
+impl Display for InputBuffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for i in self.tail..self.head {
+            write!(f, "{}", self.buf[i % BUFFER_SIZE] as char)?;
+        }
+        Ok(())
+    }
+}

--- a/kernel/src/drivers/ps_2/keyboard.rs
+++ b/kernel/src/drivers/ps_2/keyboard.rs
@@ -1,0 +1,225 @@
+// https://wiki.osdev.org/%228042%22_PS/2_Controller#PS/2_Controller_IO_Ports
+
+use kidneyos_shared::serial::inb;
+
+/// Data port           Read/Write
+///
+/// The Data Port (IO Port 0x60) is used for reading data that was received from a PS/2 device or from the PS/2 controller itself and writing data to a PS/2 device or to the PS/2 controller itself.
+static DATA_PORT: u16 = 0x60;
+/// Status register     Read
+static _STATUS_REGISTER: u16 = 0x64;
+/// Command register    Write
+static _COMMAND_REGISTER: u16 = 0x64;
+
+// Modifier Keys
+static mut L_SHIFT: bool = false;
+static mut R_SHIFT: bool = false;
+static mut L_CTRL: bool = false;
+static mut R_CTRL: bool = false;
+static mut L_ALT: bool = false;
+static mut R_ALT: bool = false;
+static mut CAPS_LOCK: bool = false;
+
+struct Keymap {
+    first_scancode: u16,
+    chars: &'static str,
+}
+
+// Scancode to key mappings
+
+/// Keys that produce the same characters regardless of Shift keys. Case of
+/// letters is handled separately.
+static INVARIANT_KEYMAP: &[Keymap] = &[
+    Keymap {
+        first_scancode: 0x01,
+        chars: "\x1B",
+    }, // Escape
+    Keymap {
+        first_scancode: 0x0e,
+        chars: "\x08",
+    }, // Backspace
+    Keymap {
+        first_scancode: 0x0f,
+        chars: "\tQWERTYUIOP",
+    },
+    Keymap {
+        first_scancode: 0x1c,
+        chars: "\r",
+    }, // Enter
+    Keymap {
+        first_scancode: 0x1e,
+        chars: "ASDFGHJKL",
+    },
+    Keymap {
+        first_scancode: 0x2c,
+        chars: "ZXCVBNM",
+    },
+    Keymap {
+        first_scancode: 0x37,
+        chars: "*",
+    },
+    Keymap {
+        first_scancode: 0x39,
+        chars: " ",
+    }, // Space
+    Keymap {
+        first_scancode: 0x53,
+        chars: "\x7F",
+    }, // Delete
+    Keymap {
+        first_scancode: 0,
+        chars: "",
+    },
+];
+
+/// Characters for keys pressed without Shift, for those keys where it matters.
+static UNSHIFTED_KEYMAP: &[Keymap] = &[
+    Keymap {
+        first_scancode: 0x02,
+        chars: "1234567890-=",
+    },
+    Keymap {
+        first_scancode: 0x1a,
+        chars: "[]",
+    },
+    Keymap {
+        first_scancode: 0x27,
+        chars: ";'`",
+    },
+    Keymap {
+        first_scancode: 0x2b,
+        chars: "\\",
+    },
+    Keymap {
+        first_scancode: 0x33,
+        chars: ",./",
+    },
+    Keymap {
+        first_scancode: 0,
+        chars: "",
+    },
+];
+
+/// Characters for keys pressed with Shift, for those keys where it matters.
+static SHIFTED_KEYMAP: &[Keymap] = &[
+    Keymap {
+        first_scancode: 0x02,
+        chars: "!@#$%^&*()_+",
+    },
+    Keymap {
+        first_scancode: 0x1a,
+        chars: "{}",
+    },
+    Keymap {
+        first_scancode: 0x27,
+        chars: ":\"~",
+    },
+    Keymap {
+        first_scancode: 0x2b,
+        chars: "|",
+    },
+    Keymap {
+        first_scancode: 0x33,
+        chars: "<>?",
+    },
+    Keymap {
+        first_scancode: 0,
+        chars: "",
+    },
+];
+
+pub fn on_keyboard_interrupt() {
+    // Modifier keys
+    let shift: bool = unsafe { L_SHIFT || R_SHIFT };
+    // TODO: Handle ctrl and alt?
+    let _ctrl: bool = unsafe { L_CTRL || R_CTRL };
+    let _alt: bool = unsafe { L_ALT || R_ALT };
+
+    // Read the scancode
+    let mut code = unsafe { inb(DATA_PORT) } as u16;
+    if code == 0xe0 {
+        // Extended scancode
+        code = code << 8 | (unsafe { inb(DATA_PORT) } as u16);
+    }
+
+    // > 0x80 means key release
+    let release: bool = code & 0x80 != 0;
+    code &= 0x7F;
+
+    // Caps Lock
+    if code == 0x3A {
+        if !release {
+            unsafe { CAPS_LOCK = !CAPS_LOCK };
+        }
+        return;
+    }
+
+    // Handle the key
+    let c = map_key(INVARIANT_KEYMAP, code)
+        .or_else(|| {
+            if !shift {
+                map_key(UNSHIFTED_KEYMAP, code)
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            if shift {
+                map_key(SHIFTED_KEYMAP, code)
+            } else {
+                None
+            }
+        });
+
+    if let Some(mut c) = c {
+        if release {
+            // No need to handle key release
+            return;
+        }
+
+        // Ordinary character
+        if shift == unsafe { CAPS_LOCK } {
+            c = c.to_ascii_lowercase();
+        }
+        // TODO: Add to buffer
+        kidneyos_shared::eprint!("{}", c as char);
+    } else {
+        // Modifier keys
+
+        match code {
+            0x2A => unsafe {
+                L_SHIFT = !release;
+            },
+            0x36 => unsafe {
+                R_SHIFT = !release;
+            },
+            0x38 => unsafe {
+                L_ALT = !release;
+            },
+            0xE038 => unsafe {
+                R_ALT = !release;
+            },
+            0x1D => unsafe {
+                L_CTRL = !release;
+            },
+            0xE01D => unsafe {
+                R_CTRL = !release;
+            },
+            _ => (),
+        }
+    }
+}
+
+/// Scans the array of keymaps `k` for `scancode`.
+fn map_key(k: &[Keymap], scancode: u16) -> Option<u8> {
+    for keymap in k {
+        if keymap.first_scancode != 0
+            && scancode >= keymap.first_scancode
+            && scancode < keymap.first_scancode + keymap.chars.len() as u16
+        {
+            let character = keymap.chars.as_bytes()[(scancode - keymap.first_scancode) as usize];
+            return Some(character);
+        }
+    }
+    None
+}

--- a/kernel/src/drivers/ps_2/keyboard.rs
+++ b/kernel/src/drivers/ps_2/keyboard.rs
@@ -1,5 +1,7 @@
 // https://wiki.osdev.org/%228042%22_PS/2_Controller#PS/2_Controller_IO_Ports
 
+use crate::system::unwrap_system;
+
 use kidneyos_shared::serial::inb;
 
 /// Data port           Read/Write
@@ -7,9 +9,9 @@ use kidneyos_shared::serial::inb;
 /// The Data Port (IO Port 0x60) is used for reading data that was received from a PS/2 device or from the PS/2 controller itself and writing data to a PS/2 device or to the PS/2 controller itself.
 static DATA_PORT: u16 = 0x60;
 /// Status register     Read
-static _STATUS_REGISTER: u16 = 0x64;
+static _STATUS_REGISTER: u16 = 0x64; // Unused
 /// Command register    Write
-static _COMMAND_REGISTER: u16 = 0x64;
+static _COMMAND_REGISTER: u16 = 0x64; // Unused
 
 // Modifier Keys
 static mut L_SHIFT: bool = false;
@@ -181,8 +183,9 @@ pub fn on_keyboard_interrupt() {
         if shift == unsafe { CAPS_LOCK } {
             c = c.to_ascii_lowercase();
         }
-        // TODO: Add to buffer
-        kidneyos_shared::eprint!("{}", c as char);
+
+        // Add to buffer
+        unsafe { unwrap_system().input_buffer.lock().putc(c) };
     } else {
         // Modifier keys
 

--- a/kernel/src/drivers/ps_2/mod.rs
+++ b/kernel/src/drivers/ps_2/mod.rs
@@ -1,0 +1,1 @@
+pub mod keyboard;

--- a/kernel/src/drivers/ps_2/mod.rs
+++ b/kernel/src/drivers/ps_2/mod.rs
@@ -1,1 +1,2 @@
+pub mod input;
 pub mod keyboard;

--- a/kernel/src/interrupts/idt.rs
+++ b/kernel/src/interrupts/idt.rs
@@ -73,7 +73,7 @@ pub unsafe fn load() {
     }
     IDT[0xe] = IDT[0xe].with_offset(page_fault_handler as usize as u32);
     IDT[0x20] = IDT[0x20].with_offset(timer_interrupt_handler as usize as u32); // PIC1_OFFSET (IRQ0)
-    IDT[0x21] = IDT[0x21].with_offset(keyboard_handler as usize as u32);
+    IDT[0x21] = IDT[0x21].with_offset(keyboard_handler as usize as u32); // Keyboard (IRQ1)
     IDT[0x2E] = IDT[0x2E].with_offset(ide_prim_interrupt_handler as usize as u32); // IDE Primary (IRQ14)
     IDT[0x2F] = IDT[0x2F].with_offset(ide_secd_interrupt_handler as usize as u32); // IDE Secondary (IRQ15)
     IDT[0x80] = IDT[0x80].with_offset(syscall_handler as usize as u32);

--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -1,6 +1,7 @@
 use core::arch::asm;
 
 use crate::drivers::ata::ata_interrupt;
+use crate::drivers::ps_2::keyboard;
 use crate::interrupts::{pic, timer};
 use crate::threading::scheduling;
 use crate::user_program::syscall;
@@ -138,12 +139,17 @@ pub unsafe extern "C" fn keyboard_handler() -> ! {
     pusha
     // Push IRQ1 value onto the stack.
     push 0X1
+    call {} // Handle keyboard interrupt
     call {} // Send EOI signal to PICs
+    call {} // Yield process
+
     add esp, 4 // Drop arguments from stack
     popa
     iretd
     ",
+    sym keyboard::on_keyboard_interrupt,
     sym pic::send_eoi,
+    sym scheduling::scheduler_yield_and_continue,
     options(noreturn),
-    );
+    )
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -28,6 +28,8 @@ extern crate alloc;
 
 use crate::block::block_core::BlockManager;
 use crate::drivers::ata::ata_core::ide_init;
+use crate::drivers::ps_2::input::InputBuffer;
+use crate::sync::mutex::Mutex;
 use crate::system::{SystemState, SYSTEM};
 use crate::threading::process::create_process_state;
 use crate::threading::thread_control_block::ThreadControlBlock;
@@ -88,6 +90,7 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
         let ide_tcb = ThreadControlBlock::new_with_setup(ide_addr, 0, &mut process);
 
         let block_manager = BlockManager::default();
+        let input_buffer = Mutex::new(InputBuffer::new());
 
         threads.scheduler.push(Box::new(ide_tcb));
 
@@ -96,6 +99,7 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
             process,
 
             block_manager,
+            input_buffer,
         });
 
         println!("Mounting root filesystem...");

--- a/kernel/src/system.rs
+++ b/kernel/src/system.rs
@@ -1,4 +1,6 @@
 use crate::block::block_core::BlockManager;
+use crate::drivers::ps_2::input::InputBuffer;
+use crate::sync::mutex::Mutex;
 use crate::threading::process::{Pid, ProcessState, Tid};
 use crate::threading::thread_control_block::{ProcessControlBlock, ThreadControlBlock};
 use crate::threading::ThreadState;
@@ -9,6 +11,7 @@ pub struct SystemState {
     pub process: ProcessState,
 
     pub block_manager: BlockManager,
+    pub input_buffer: Mutex<InputBuffer>,
 }
 
 pub static mut SYSTEM: Option<SystemState> = None;


### PR DESCRIPTION
Adds keyboard support. To get the input buffer, 
```rust
unwrap_system().input_buffer.lock().getc() -> Option<u8>
```