### PR TITLE
Fix issue with exited process not properly dropping threads

### DIFF
--- a/kernel/src/threading/context_switch.rs
+++ b/kernel/src/threading/context_switch.rs
@@ -1,4 +1,7 @@
-use crate::interrupts::{intr_get_level, IntrLevel};
+use crate::{
+    interrupts::{intr_get_level, IntrLevel},
+    threading::thread_functions::clean_up_thread,
+};
 use core::mem::offset_of;
 
 use super::thread_control_block::{ThreadControlBlock, ThreadStatus};
@@ -45,7 +48,7 @@ pub unsafe fn switch_threads(
     let page_manager = &(*switch_to).page_manager;
     page_manager.load();
 
-    let mut previous = Box::from_raw(context_switch(switch_from, switch_to));
+    let previous = Box::from_raw(context_switch(switch_from, switch_to));
 
     // We must mark this thread as running once again.
     (*switch_from).status = ThreadStatus::Running;
@@ -54,12 +57,7 @@ pub unsafe fn switch_threads(
     threads.running_thread = Some(Box::from_raw(switch_from));
 
     if previous.status == ThreadStatus::Dying {
-        previous.reap();
-
-        // Page manager must be loaded when dropped.
-        previous.page_manager.load();
-        drop(previous);
-        threads.running_thread.as_ref().unwrap().page_manager.load();
+        clean_up_thread(previous);
     } else {
         threads.scheduler.push(previous);
     }

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -42,7 +42,7 @@ pub fn exit_thread(exit_code: i32) -> ! {
     }
 }
 
-unsafe fn clean_up_thread(mut dying_thread: Box<ThreadControlBlock>) {
+pub unsafe fn clean_up_thread(mut dying_thread: Box<ThreadControlBlock>) {
     let threads = &mut unwrap_system_mut().threads;
 
     dying_thread.reap();

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -46,7 +46,7 @@ unsafe fn clean_up_thread(mut dying_thread: Box<ThreadControlBlock>) {
     let threads = &mut unwrap_system_mut().threads;
 
     dying_thread.reap();
-    
+
     // Page manager must be loaded to be dropped.
     dying_thread.page_manager.load();
     drop(dying_thread);

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -44,7 +44,13 @@ pub unsafe fn clean_up_thread(mut dying_thread: Box<ThreadControlBlock>) {
     // Page manager must be loaded to be dropped.
     dying_thread.page_manager.load();
     drop(dying_thread);
-    threads.running_thread.lock().as_ref().unwrap().page_manager.load();
+    threads
+        .running_thread
+        .lock()
+        .as_ref()
+        .unwrap()
+        .page_manager
+        .load();
 }
 
 // Focibly stops the thread specified by Tid

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -42,12 +42,22 @@ pub fn exit_thread(exit_code: i32) -> ! {
     }
 }
 
+unsafe fn clean_up_thread(mut dying_thread: Box<ThreadControlBlock>) {
+    let threads = &mut unwrap_system_mut().threads;
+
+    dying_thread.reap();
+    
+    // Page manager must be loaded to be dropped.
+    dying_thread.page_manager.load();
+    drop(dying_thread);
+    threads.running_thread.as_ref().unwrap().page_manager.load();
+}
+
 // Focibly stops the thread specified by Tid
 pub fn stop_thread(tid: Tid) {
     let scheduler = unsafe { unwrap_system_mut().threads.scheduler.as_mut() };
-    let tcb = scheduler.get_mut(tid).expect("Why is nothing running !?");
-    tcb.status = ThreadStatus::Dying;
-    tcb.set_exit_code(-1);
+    let tcb = scheduler.remove(tid).expect("Why is nothing running !?");
+    unsafe { clean_up_thread(tcb) };
 }
 
 /// A wrapper function to execute a thread's true function.
@@ -69,15 +79,10 @@ unsafe extern "C" fn run_thread(
     // Reschedule our threads.
     threads.running_thread = Some(switched_to);
 
-    let mut switched_from = Box::from_raw(switched_from);
+    let switched_from = Box::from_raw(switched_from);
 
     if switched_from.status == ThreadStatus::Dying {
-        switched_from.reap();
-
-        // Page manager must be loaded to be dropped.
-        switched_from.page_manager.load();
-        drop(switched_from);
-        threads.running_thread.as_ref().unwrap().page_manager.load();
+        clean_up_thread(switched_from);
     } else {
         threads.scheduler.push(switched_from);
     }


### PR DESCRIPTION
The implementation of the process_exit function was not properly disposing of non-running child threads of the current process. This hasn't resulted in any issues yet as there is currently no multi-threadding support and the last running child is disposed of properly.