### PR TITLE
Don't use indirect EIP for TCB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,11 @@ run-qemu-ng: $(ISO)
 	# NOTE: You can quit with Ctrl-A X
 	qemu-system-i386 -nographic $(QEMU_FLAGS)
 
+.PHONY: run-qemu-ng-gdb
+run-qemu-ng-gdb: $(ISO) build/kernel.sym
+	# NOTE: You can quit with Ctrl-A X
+	qemu-system-i386 -nographic -s -S $(QEMU_FLAGS)
+
 # Docs
 
 .PHONY: docs

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -54,12 +54,6 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
 
 const INIT: &[u8] = include_bytes!("../../programs/exit/exit").as_slice();
 
-fn thread_do_nothing() {
-    loop {
-
-    }
-}
-
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
     unsafe {
@@ -94,15 +88,11 @@ extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {
 
         let ide_addr = NonNull::new(ide_init as *const () as *mut u8).unwrap();
         let ide_tcb = ThreadControlBlock::new_with_setup(ide_addr, true, &mut process);
-        
-        let thread_do_nothin = NonNull::new(thread_do_nothing as *const () as *mut u8).unwrap();
-        let thread_do_nothing_tcb = ThreadControlBlock::new_with_setup(thread_do_nothin, true, &mut process);
 
         let block_manager = BlockManager::default();
         let input_buffer = Mutex::new(InputBuffer::new());
 
         threads.scheduler.push(Box::new(ide_tcb));
-        threads.scheduler.push(Box::new(thread_do_nothing_tcb));
 
         SYSTEM = Some(SystemState {
             threads,

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -216,7 +216,13 @@ impl ThreadControlBlock {
 
     #[allow(unused)]
     pub fn new_with_setup(eip: NonNull<u8>, is_kernel: bool, state: &mut ProcessState) -> Self {
-        let mut new_thread = Self::new(eip, is_kernel, state.allocate_pid(), PageManager::default(), state);
+        let mut new_thread = Self::new(
+            eip,
+            is_kernel,
+            state.allocate_pid(),
+            PageManager::default(),
+            state,
+        );
 
         // Now, we must build the stack frames for our new thread.
         // In order (of creation), we have:
@@ -240,7 +246,7 @@ impl ThreadControlBlock {
         }
 
         new_thread.eip = eip; // !!!
-        
+
         // Our thread can now be run via the `switch_threads` method.
         new_thread.status = ThreadStatus::Ready;
         new_thread

--- a/kernel/src/threading/thread_functions.rs
+++ b/kernel/src/threading/thread_functions.rs
@@ -64,7 +64,12 @@ unsafe extern "C" fn run_thread(
 
     TASK_STATE_SEGMENT.esp0 = switched_to.kernel_stack.as_ptr() as u32;
 
-    let ThreadControlBlock { eip, esp, is_kernel, .. } = *switched_to;
+    let ThreadControlBlock {
+        eip,
+        esp,
+        is_kernel,
+        ..
+    } = *switched_to;
 
     // Reschedule our threads.
     threads.running_thread = Some(switched_to);


### PR DESCRIPTION
We have an interpretation problem for our `eip` variable in our TCB struct. There are two cases:

 - If pid == 0, this thread is considered a kernel thread, and `eip` is the pointer to be a **pointer to a pointer** to the entry of the thread.
 - If pid != 0, this thread is considered a user thread, and `eip` is considered to be a **pointer** to the entry of the thread.
 
 This PR decouples these behaviours and avoids some crashes with multiple TCBs.