### PR TITLE
Read execve executable from disk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         flake_paths: ./nix#devShells.x86_64-linux.build
     - name: Check formatting
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}
-      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c sh -c 'find -name "*.rs" -print0 | xargs -0 rustfmt --quiet --check -- --edition 2021'
+      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c sh -c 'find -name "*.rs" -print0 | xargs -0 rustfmt --quiet --check --edition 2021 --'
     - name: Build test programs
       id: test-programs
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         flake_paths: ./nix#devShells.x86_64-linux.build
     - name: Check formatting
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}
-      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c sh -c 'find -name "*.rs" -print0 | xargs -0 rustfmt --quiet --check --'
+      run: nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ./nix#build -i -k CARGO_TERM_COLOR -c sh -c 'find -name "*.rs" -print0 | xargs -0 rustfmt --quiet --check -- --edition 2021'
     - name: Build test programs
       id: test-programs
       if: ${{ !cancelled() && steps.cache-nix.outcome == 'success' }}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -52,7 +52,7 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-const INIT: &[u8] = include_bytes!("../../programs/exit/exit").as_slice();
+const INIT: &[u8] = include_bytes!("../../programs/execve/target/i686-unknown-linux-gnu/release/execve").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -53,7 +53,7 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
 }
 
 const INIT: &[u8] =
-    include_bytes!("../../programs/execve/target/i686-unknown-linux-gnu/release/execve").as_slice();
+    include_bytes!("../../programs/exit/exit").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -52,8 +52,7 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-const INIT: &[u8] =
-    include_bytes!("../../programs/exit/exit").as_slice();
+const INIT: &[u8] = include_bytes!("../../programs/exit/exit").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -52,7 +52,8 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-const INIT: &[u8] = include_bytes!("../../programs/execve/target/i686-unknown-linux-gnu/release/execve").as_slice();
+const INIT: &[u8] =
+    include_bytes!("../../programs/execve/target/i686-unknown-linux-gnu/release/execve").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -57,7 +57,8 @@ pub fn thread_system_start(kernel_page_manager: PageManager, init_elf: &[u8]) ->
         let elf = Elf::parse_bytes(init_elf).expect("failed to parse provided elf file");
 
         // Create the initial user program thread.
-        let user_tcb = ThreadControlBlock::new_from_elf(elf, &mut system.process);
+        let user_tcb = ThreadControlBlock::new_from_elf(elf, &mut system.process)
+            .expect("Failed to parse Elf for initial program.");
 
         // SAFETY: Interrupts must be disabled.
         system.threads.running_thread = Some(Box::new(kernel_tcb));

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -106,16 +106,19 @@ pub enum ThreadElfCreateError {
 }
 
 impl ThreadControlBlock {
-    pub fn new_from_elf(elf: Elf, state: &mut ProcessState) -> Result<ThreadControlBlock, ThreadElfCreateError> {
+    pub fn new_from_elf(
+        elf: Elf,
+        state: &mut ProcessState,
+    ) -> Result<ThreadControlBlock, ThreadElfCreateError> {
         // Shared ELFs can count as a "Relocatable Executable" if the entry point is set.
         let executable = matches!(elf.header.usage, ElfUsage::Executable | ElfUsage::Shared);
 
         if !executable {
-            return Err(ThreadElfCreateError::NotExecutable)
+            return Err(ThreadElfCreateError::NotExecutable);
         }
-        
+
         if elf.header.architecture != ElfArchitecture::X86 {
-            return Err(ThreadElfCreateError::UnsupportedArchitecture)
+            return Err(ThreadElfCreateError::UnsupportedArchitecture);
         }
 
         let ppid = unsafe {

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -106,7 +106,10 @@ pub enum ThreadElfCreateError {
 }
 
 impl ThreadControlBlock {
-    pub fn new_from_elf(elf: Elf, state: &ProcessState) -> Result<ThreadControlBlock, ThreadElfCreateError> {
+    pub fn new_from_elf(
+        elf: Elf,
+        state: &ProcessState,
+    ) -> Result<ThreadControlBlock, ThreadElfCreateError> {
         // Shared ELFs can count as a "Relocatable Executable" if the entry point is set.
         let executable = matches!(elf.header.usage, ElfUsage::Executable | ElfUsage::Shared);
 

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -63,8 +63,8 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
                 Err(CStrError::BadUtf8) => return -ENOENT, // ?
             };
 
-            let Ok(data) = read_file(cstr) else { 
-                return -EIO
+            let Ok(data) = read_file(cstr) else {
+                return -EIO;
             };
 
             let elf = Elf::parse_bytes(&data).ok();

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -63,9 +63,8 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
                 Err(CStrError::BadUtf8) => return -ENOENT, // ?
             };
 
-            let data = match read_file(cstr) {
-                Ok(data) => data,
-                Err(_) => return -EIO,
+            let Ok(data) = read_file(cstr) else { 
+                return -EIO
             };
 
             let elf = Elf::parse_bytes(&data).ok();

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -1,5 +1,6 @@
 // https://docs.google.com/document/d/1qMMU73HW541wME00Ngl79ou-kQ23zzTlGXJYo9FNh5M
 
+use crate::fs::read_file;
 use crate::fs::syscalls::{
     chdir, close, fstat, ftruncate, getcwd, getdents, link, lseek64, mkdir, mount, open, read,
     rename, rmdir, symlink, sync, unlink, unmount, write,
@@ -16,7 +17,6 @@ use alloc::boxed::Box;
 use core::slice::from_raw_parts_mut;
 use kidneyos_shared::println;
 pub use kidneyos_syscalls::defs::*;
-use crate::fs::read_file;
 
 /// This function is responsible for processing syscalls made by user programs.
 /// Its return value is the syscall return value, whose meaning depends on the syscall.
@@ -74,7 +74,7 @@ pub extern "C" fn handler(syscall_number: usize, arg0: usize, arg1: usize, arg2:
 
             let system = unsafe { unwrap_system_mut() };
             let Ok(control) = ThreadControlBlock::new_from_elf(elf, &mut system.process) else {
-                return -ENOEXEC
+                return -ENOEXEC;
             };
 
             unsafe {

--- a/programs/execve/src/main.rs
+++ b/programs/execve/src/main.rs
@@ -13,33 +13,28 @@ const TARGET_PATH: *const c_char = c"/example_rust".as_ptr();
 pub extern "C" fn _start() -> ! {
     // TempFS - We'll create the file that we want to execute on the fly.
     let fd = kidneyos_syscalls::open(TARGET_PATH, O_CREATE);
-    
+
     if fd < 0 {
         kidneyos_syscalls::exit(fd);
     }
-    
+
     let result = kidneyos_syscalls::write(fd, TARGET_PROGRAM.as_ptr(), TARGET_PROGRAM.len());
-    
+
     if result < 0 {
         kidneyos_syscalls::exit(result);
     }
-    
+
     // Flush?
     kidneyos_syscalls::close(fd);
-    
-    let argv = [
-        TARGET_PATH,
-        core::ptr::null()
-    ];
 
-    let envp = [
-        core::ptr::null()
-    ];
+    let argv = [TARGET_PATH, core::ptr::null()];
+
+    let envp = [core::ptr::null()];
 
     let result = kidneyos_syscalls::execve(TARGET_PATH, argv.as_ptr(), envp.as_ptr());
-    
+
     kidneyos_syscalls::exit(result);
-    
+
     loop {}
 }
 

--- a/programs/execve/src/main.rs
+++ b/programs/execve/src/main.rs
@@ -1,15 +1,45 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
+use core::ffi::c_char;
+use kidneyos_syscalls::O_CREATE;
+
 const TARGET_PROGRAM: &[u8] =
     include_bytes!("../../example_rust/target/i686-unknown-linux-gnu/release/example_rust");
 
+const TARGET_PATH: *const c_char = c"/example_rust".as_ptr();
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    kidneyos_syscalls::execve(TARGET_PROGRAM.as_ptr(), TARGET_PROGRAM.len());
-
-    kidneyos_syscalls::exit(2);
-
+    let argv = [
+        TARGET_PATH,
+        core::ptr::null()
+    ];
+    
+    let envp = [
+        core::ptr::null()
+    ];
+    
+    // TempFS - We'll create the file that we want to execute on the fly.
+    let fd = kidneyos_syscalls::open(TARGET_PATH, O_CREATE);
+    
+    if fd < 0 {
+        kidneyos_syscalls::exit(fd);
+    }
+    
+    let result = kidneyos_syscalls::write(fd, TARGET_PROGRAM.as_ptr(), TARGET_PROGRAM.len());
+    
+    if result < 0 {
+        kidneyos_syscalls::exit(result);
+    }
+    
+    // Flush?
+    kidneyos_syscalls::close(fd);
+    
+    let result = kidneyos_syscalls::execve(TARGET_PATH, argv.as_ptr(), envp.as_ptr());
+    
+    kidneyos_syscalls::exit(result);
+    
     loop {}
 }
 

--- a/programs/execve/src/main.rs
+++ b/programs/execve/src/main.rs
@@ -11,15 +11,6 @@ const TARGET_PATH: *const c_char = c"/example_rust".as_ptr();
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    let argv = [
-        TARGET_PATH,
-        core::ptr::null()
-    ];
-    
-    let envp = [
-        core::ptr::null()
-    ];
-    
     // TempFS - We'll create the file that we want to execute on the fly.
     let fd = kidneyos_syscalls::open(TARGET_PATH, O_CREATE);
     
@@ -36,6 +27,15 @@ pub extern "C" fn _start() -> ! {
     // Flush?
     kidneyos_syscalls::close(fd);
     
+    let argv = [
+        TARGET_PATH,
+        core::ptr::null()
+    ];
+
+    let envp = [
+        core::ptr::null()
+    ];
+
     let result = kidneyos_syscalls::execve(TARGET_PATH, argv.as_ptr(), envp.as_ptr());
     
     kidneyos_syscalls::exit(result);

--- a/scripts/generate-disk.bash
+++ b/scripts/generate-disk.bash
@@ -98,19 +98,19 @@ if [[ "$user" == "root" ]]; then
   exit 1
 fi
 
-if groups "$user" | grep -qE "\bsudo\b|\bwheel\b"; then
-  echo "Warning: This script requires elevated privileges (sudo) and performs disk manipulations."
-  echo "Please review the script carefully to avoid potential data loss or system damage."
-
-  read -r -p "Do you wish to proceed? [y/N]: " response
-  if [[ "$response" != "y" && "$response" != "Y" ]]; then
-    echo "Operation aborted by the user."
-    exit 1
-  fi
-else
-  echo "Error: You do not have the necessary sudo privileges. Please run the script as a user with sufficient permissions."
-  exit 1
-fi
+#if groups "$user" | grep -qE "\bsudo\b|\bwheel\b"; then
+#  echo "Warning: This script requires elevated privileges (sudo) and performs disk manipulations."
+#  echo "Please review the script carefully to avoid potential data loss or system damage."
+#
+#  read -r -p "Do you wish to proceed? [y/N]: " response
+#  if [[ "$response" != "y" && "$response" != "Y" ]]; then
+#    echo "Operation aborted by the user."
+#    exit 1
+#  fi
+#else
+#  echo "Error: You do not have the necessary sudo privileges. Please run the script as a user with sufficient permissions."
+#  exit 1
+#fi
 
 # Create disk image --------------------------------------------------------------------------------
 

--- a/syscalls/include/kidneyos.h
+++ b/syscalls/include/kidneyos.h
@@ -22,6 +22,8 @@
 
 #define EIO 5
 
+#define ENOEXEC 8
+
 #define EBADF 9
 
 #define EFAULT 14
@@ -157,7 +159,7 @@ typedef struct Timespec {
   int64_t tv_nsec;
 } Timespec;
 
-void exit(uintptr_t code);
+void exit(int32_t code);
 
 Pid fork(void);
 
@@ -165,7 +167,7 @@ int32_t read(int32_t fd, uint8_t *buffer, uintptr_t count);
 
 int32_t write(int32_t fd, const uint8_t *buffer, uintptr_t count);
 
-int32_t open(const uint8_t *name, uintptr_t flags);
+int32_t open(const char *name, uintptr_t flags);
 
 int32_t close(int32_t fd);
 
@@ -173,21 +175,21 @@ int64_t lseek64(int32_t fd, int64_t offset, int32_t whence);
 
 int32_t getcwd(int8_t *buf, uintptr_t size);
 
-int32_t chdir(const int8_t *path);
+int32_t chdir(const char *path);
 
-int32_t mkdir(const int8_t *path);
+int32_t mkdir(const char *path);
 
 int32_t fstat(int32_t fd, struct Stat *statbuf);
 
-int32_t unlink(const int8_t *path);
+int32_t unlink(const char *path);
 
-int32_t link(const int8_t *source, const int8_t *dest);
+int32_t link(const char *source, const char *dest);
 
-int32_t symlink(const int8_t *source, const int8_t *dest);
+int32_t symlink(const char *source, const char *dest);
 
-int32_t rename(const int8_t *source, const int8_t *dest);
+int32_t rename(const char *source, const char *dest);
 
-int32_t rmdir(const int8_t *path);
+int32_t rmdir(const char *path);
 
 int32_t getdents(int32_t fd, struct Dirent *output, uintptr_t size);
 
@@ -195,13 +197,13 @@ int32_t ftruncate(int32_t fd, uint64_t size);
 
 int32_t sync(void);
 
-int32_t unmount(const int8_t *path);
+int32_t unmount(const char *path);
 
-int32_t mount(const int8_t *device, const int8_t *target, const int8_t *filesystem_type);
+int32_t mount(const char *device, const char *target, const char *filesystem_type);
 
 Pid waitpid(Pid pid, int32_t *stat, int32_t options);
 
-void execve(const uint8_t *elf_bytes, uintptr_t byte_count);
+int32_t execve(const char *filename, const char *const *argv, const char *const *envp);
 
 int32_t nanosleep(const struct Timespec *duration, struct Timespec *remainder);
 

--- a/syscalls/src/defs.rs
+++ b/syscalls/src/defs.rs
@@ -31,6 +31,7 @@ pub const SEEK_END: i32 = 2;
 
 pub const ENOENT: isize = 2;
 pub const EIO: isize = 5;
+pub const ENOEXEC: isize = 8;
 pub const EBADF: isize = 9;
 pub const EFAULT: isize = 14;
 pub const EBUSY: isize = 16;

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -250,7 +250,11 @@ pub extern "C" fn unmount(path: *const c_char) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn mount(device: *const c_char, target: *const c_char, filesystem_type: *const c_char) -> i32 {
+pub extern "C" fn mount(
+    device: *const c_char,
+    target: *const c_char,
+    filesystem_type: *const c_char,
+) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -282,7 +286,7 @@ pub extern "C" fn waitpid(pid: Pid, stat: *mut i32, options: i32) -> Pid {
 pub extern "C" fn execve(
     filename: *const c_char,
     argv: *const *const c_char,
-    envp: *const *const c_char
+    envp: *const *const c_char,
 ) -> i32 {
     let result: i32;
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use core::arch::asm;
+use core::ffi::c_char;
 
 pub type Pid = u16;
 
@@ -14,7 +15,7 @@ pub mod defs;
 pub use defs::*;
 
 #[no_mangle]
-pub extern "C" fn exit(code: usize) {
+pub extern "C" fn exit(code: i32) {
     unsafe {
         asm!(
             "
@@ -65,7 +66,7 @@ pub extern "C" fn write(fd: i32, buffer: *const u8, count: usize) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn open(name: *const u8, flags: usize) -> i32 {
+pub extern "C" fn open(name: *const c_char, flags: usize) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -116,7 +117,7 @@ pub extern "C" fn getcwd(buf: *mut i8, size: usize) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn chdir(path: *const i8) -> i32 {
+pub extern "C" fn chdir(path: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -127,7 +128,7 @@ pub extern "C" fn chdir(path: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn mkdir(path: *const i8) -> i32 {
+pub extern "C" fn mkdir(path: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -149,7 +150,7 @@ pub extern "C" fn fstat(fd: i32, statbuf: *mut Stat) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn unlink(path: *const i8) -> i32 {
+pub extern "C" fn unlink(path: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -160,7 +161,7 @@ pub extern "C" fn unlink(path: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn link(source: *const i8, dest: *const i8) -> i32 {
+pub extern "C" fn link(source: *const c_char, dest: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -171,7 +172,7 @@ pub extern "C" fn link(source: *const i8, dest: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn symlink(source: *const i8, dest: *const i8) -> i32 {
+pub extern "C" fn symlink(source: *const c_char, dest: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -182,7 +183,7 @@ pub extern "C" fn symlink(source: *const i8, dest: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rename(source: *const i8, dest: *const i8) -> i32 {
+pub extern "C" fn rename(source: *const c_char, dest: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -193,7 +194,7 @@ pub extern "C" fn rename(source: *const i8, dest: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rmdir(path: *const i8) -> i32 {
+pub extern "C" fn rmdir(path: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -238,7 +239,7 @@ pub extern "C" fn sync() -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn unmount(path: *const i8) -> i32 {
+pub extern "C" fn unmount(path: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -249,7 +250,7 @@ pub extern "C" fn unmount(path: *const i8) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn mount(device: *const i8, target: *const i8, filesystem_type: *const i8) -> i32 {
+pub extern "C" fn mount(device: *const c_char, target: *const c_char, filesystem_type: *const c_char) -> i32 {
     let result;
     unsafe {
         asm!("
@@ -277,38 +278,28 @@ pub extern "C" fn waitpid(pid: Pid, stat: *mut i32, options: i32) -> Pid {
     result as Pid
 }
 
-// Temporarily defining execve as (elf_bytes: *const u8, count: usize) while FS comes together.
-/*
 #[no_mangle]
 pub extern "C" fn execve(
-    filename: *const i8,
-    argv: *const *const i8,
-    envp: *const *const i8,
+    filename: *const c_char,
+    argv: *const *const c_char,
+    envp: *const *const c_char
 ) -> i32 {
     let result: i32;
+
     unsafe {
-        asm!("
+        asm!(
+            "
             mov eax, 0x0b
             int 0x80
             ",
             in("ebx") filename,
             in("ecx") argv,
             in("edx") envp,
-            lateout("eax") result,
-        );
+            lateout("eax") result
+        )
     }
-    result
-}
-*/
 
-#[no_mangle]
-pub extern "C" fn execve(elf_bytes: *const u8, byte_count: usize) {
-    unsafe {
-        asm!("
-            mov eax, 0x0b
-            int 0x80
-        ", in("ebx") elf_bytes, in("ecx") byte_count)
-    }
+    result
 }
 
 // Seems to reference __kernel_timespec as the inputs for this syscall.


### PR DESCRIPTION
The `execve` syscall now uses the disk! Hooray!

`argv` and `envp` are ignored.