### PR TITLE
Add support for VMAs

### DIFF
--- a/kernel/src/fs/fs_manager.rs
+++ b/kernel/src/fs/fs_manager.rs
@@ -1207,6 +1207,7 @@ mod test {
             child_tids: vec![],
             waiting_thread: None,
             exit_code: None,
+            vmas: Default::default(),
             cwd: root.get_root().unwrap(),
             cwd_path: "/".into(),
         }

--- a/kernel/src/interrupts/idt.rs
+++ b/kernel/src/interrupts/idt.rs
@@ -7,8 +7,9 @@ use kidneyos_shared::{bit_array::BitArray, bitfield};
 use paste::paste;
 
 use crate::interrupts::intr_handler::{
-    ide_prim_interrupt_handler, ide_secd_interrupt_handler, keyboard_handler, page_fault_handler,
-    syscall_handler, timer_interrupt_handler, unhandled_handler,
+    general_protection_fault_handler, ide_prim_interrupt_handler, ide_secd_interrupt_handler,
+    keyboard_handler, page_fault_handler, syscall_handler, timer_interrupt_handler,
+    unhandled_handler,
 };
 
 bitfield!(
@@ -71,6 +72,7 @@ pub unsafe fn load() {
             .with_descriptor_privilege_level(3u8)
             .with_present(true);
     }
+    IDT[0xd] = IDT[0xd].with_offset(general_protection_fault_handler as usize as u32);
     IDT[0xe] = IDT[0xe].with_offset(page_fault_handler as usize as u32);
     IDT[0x20] = IDT[0x20].with_offset(timer_interrupt_handler as usize as u32); // PIC1_OFFSET (IRQ0)
     IDT[0x21] = IDT[0x21].with_offset(keyboard_handler as usize as u32); // Keyboard (IRQ1)

--- a/kernel/src/interrupts/intr_handler.rs
+++ b/kernel/src/interrupts/intr_handler.rs
@@ -2,7 +2,7 @@ use core::arch::asm;
 
 use crate::drivers::ata::ata_interrupt;
 use crate::drivers::input::keyboard;
-use crate::interrupts::{pic, timer};
+use crate::interrupts::{intr_enable, pic, timer};
 use crate::system::running_process;
 use crate::threading::scheduling;
 use crate::user_program::syscall;
@@ -29,6 +29,8 @@ pub unsafe extern "C" fn page_fault_handler() -> ! {
     unsafe fn inner(error_code: u32, return_eip: usize) {
         let vaddr: usize;
         asm!("mov {}, cr2", out(reg) vaddr);
+        // important: re-enable interrupts before acquiring lock to prevent deadlock
+        intr_enable();
         let pcb = running_process();
         let pcb = pcb.lock();
         // try checking for a VMA matching this address

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -53,7 +53,7 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-const INIT: &[u8] = include_bytes!("../../programs/fs/build/basic").as_slice();
+const INIT: &[u8] = include_bytes!("../../programs/exit/exit").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -53,7 +53,7 @@ fn panic(args: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-const INIT: &[u8] = include_bytes!("../../programs/exit/exit").as_slice();
+const INIT: &[u8] = include_bytes!("../../programs/fs/build/basic").as_slice();
 
 #[cfg_attr(not(test), no_mangle)]
 extern "C" fn main(mem_upper: usize, video_memory_skip_lines: usize) -> ! {

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -2,6 +2,7 @@ mod buddy_allocator;
 mod frame_allocator;
 pub mod user;
 pub mod util;
+pub mod vma;
 
 use alloc::vec::Vec;
 use buddy_allocator::BuddyAllocator;

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -140,5 +140,8 @@ impl VMAList {
         self.0.insert(addr, vma);
         true
     }
+    pub fn iter(&self) -> impl '_ + Iterator<Item = (usize, &VMA)> {
+        self.0.iter().map(|(&k, v)| (k, v))
+    }
     // TODO: free physical memory allocated by VMAs on process exit
 }

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -1,8 +1,8 @@
 use crate::fs::FileDescriptor;
-use crate::KERNEL_ALLOCATOR;
 use crate::system::unwrap_system;
-use kidneyos_shared::mem::{OFFSET, PAGE_FRAME_SIZE};
+use crate::KERNEL_ALLOCATOR;
 use alloc::collections::BTreeMap;
+use kidneyos_shared::mem::{OFFSET, PAGE_FRAME_SIZE};
 
 #[derive(Debug, Default, Clone)]
 pub struct VMAList(BTreeMap<usize, VMA>);
@@ -59,7 +59,8 @@ impl VMA {
         let phys_addr = frame_ptr.as_ptr() as *const u8 as usize - OFFSET;
         let mut tcb_guard = unwrap_system().threads.running_thread.lock();
         let tcb = tcb_guard.as_mut().expect("no running thread");
-        tcb.page_manager.map(phys_addr, virt_addr, self.writeable(), true);
+        tcb.page_manager
+            .map(phys_addr, virt_addr, self.writeable(), true);
         drop(tcb_guard);
         match self.info {
             VMAInfo::Stack | VMAInfo::Data => {
@@ -67,7 +68,7 @@ impl VMA {
                 (virt_addr as *mut u8).write_bytes(0, PAGE_FRAME_SIZE);
                 true
             }
-            VMAInfo::MMap { .. } => todo!()
+            VMAInfo::MMap { .. } => todo!(),
         }
     }
 }

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -1,5 +1,6 @@
-use crate::fs::FileDescriptor;
+use crate::fs::fs_manager::FileSystemID;
 use crate::system::unwrap_system;
+use crate::vfs::INodeNum;
 use crate::KERNEL_ALLOCATOR;
 use alloc::collections::BTreeMap;
 use kidneyos_shared::mem::{OFFSET, PAGE_FRAME_SIZE};
@@ -25,7 +26,13 @@ pub enum VMAInfo {
     /// This VMA contains the heap
     Heap,
     /// This VMA contains a memory-mapped file
-    MMap { fd: FileDescriptor, offset: u64 },
+    ///
+    /// `offset` is in units of pages
+    MMap {
+        fs: FileSystemID,
+        inode: INodeNum,
+        offset: u32,
+    },
 }
 
 impl Clone for VMAInfo {

--- a/kernel/src/mem/vma.rs
+++ b/kernel/src/mem/vma.rs
@@ -1,0 +1,122 @@
+use crate::fs::FileDescriptor;
+use crate::KERNEL_ALLOCATOR;
+use crate::system::unwrap_system;
+use kidneyos_shared::mem::{OFFSET, PAGE_FRAME_SIZE};
+use alloc::collections::BTreeMap;
+
+#[derive(Debug, Default, Clone)]
+pub struct VMAList(BTreeMap<usize, VMA>);
+
+#[derive(Debug, Clone)]
+pub struct VMA {
+    info: VMAInfo,
+    size: usize,
+    writeable: bool,
+}
+
+#[derive(Debug)]
+pub enum VMAInfo {
+    Stack,
+    Data,
+    MMap { fd: FileDescriptor, offset: u64 },
+}
+
+impl Clone for VMAInfo {
+    /// clone VMAInfo on fork
+    fn clone(&self) -> Self {
+        match self {
+            Self::Stack => Self::Stack,
+            Self::Data => Self::Data,
+            Self::MMap { .. } => todo!("increment ref count to mmapped file"),
+        }
+    }
+}
+
+impl VMA {
+    pub fn new(info: VMAInfo, size: usize, writeable: bool) -> Self {
+        Self {
+            info,
+            size,
+            writeable,
+        }
+    }
+    pub fn info(&self) -> &VMAInfo {
+        &self.info
+    }
+    pub fn size(&self) -> usize {
+        self.size
+    }
+    pub fn writeable(&self) -> bool {
+        self.writeable
+    }
+    #[must_use]
+    unsafe fn install_in_page_table(&self, virt_addr: usize, offset: usize) -> bool {
+        debug_assert_eq!(virt_addr % PAGE_FRAME_SIZE, 0);
+        debug_assert_eq!(offset % PAGE_FRAME_SIZE, 0);
+        let Ok(frame_ptr) = (unsafe { KERNEL_ALLOCATOR.frame_alloc(1) }) else {
+            return false;
+        };
+        let phys_addr = frame_ptr.as_ptr() as *const u8 as usize - OFFSET;
+        let mut tcb_guard = unwrap_system().threads.running_thread.lock();
+        let tcb = tcb_guard.as_mut().expect("no running thread");
+        tcb.page_manager.map(phys_addr, virt_addr, self.writeable(), true);
+        drop(tcb_guard);
+        match self.info {
+            VMAInfo::Stack | VMAInfo::Data => {
+                // zero memory, to prevent data from being leaked between processes.
+                (virt_addr as *mut u8).write_bytes(0, PAGE_FRAME_SIZE);
+                true
+            }
+            VMAInfo::MMap { .. } => todo!()
+        }
+    }
+}
+
+impl VMAList {
+    /// New empty list of VMAs.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    fn vma_at(&self, addr: usize) -> Option<(usize, &VMA)> {
+        let (vma_addr, vma) = self.0.range(..=addr).next()?;
+        let vma_addr = *vma_addr;
+        if addr >= vma_addr && addr < vma_addr + vma.size {
+            Some((vma_addr, vma))
+        } else {
+            None
+        }
+    }
+    fn is_address_range_free(&self, range: core::ops::Range<usize>) -> bool {
+        if self.vma_at(range.start).is_some() {
+            return false;
+        }
+        self.0.range(range.start..range.end).next().is_none()
+    }
+    /// Install PTE for virtual address `addr`, if possible.
+    ///
+    /// Returns `false` on failure, e.g. couldn't allocate physical memory, there is no VMA covering `addr`,
+    /// couldn't read mmapped file.
+    ///
+    /// # Safety
+    ///
+    /// `addr` must be currently unmapped.
+    #[must_use]
+    pub unsafe fn install_pte(&self, addr: usize) -> bool {
+        // round down to page
+        let addr = addr & !(PAGE_FRAME_SIZE - 1);
+        let Some((vma_addr, vma)) = self.vma_at(addr) else {
+            return false;
+        };
+        vma.install_in_page_table(addr, addr - vma_addr)
+    }
+    #[must_use]
+    pub fn add_vma(&mut self, vma: VMA, addr: usize) -> bool {
+        assert_eq!(addr % PAGE_FRAME_SIZE, 0);
+        if !self.is_address_range_free(addr..addr + vma.size) {
+            return false;
+        }
+        self.0.insert(addr, vma);
+        true
+    }
+    // TODO: free physical memory allocated by VMAs on process exit
+}

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -4,7 +4,7 @@ use crate::threading::process::{Pid, ProcessState, Tid};
 use crate::user_program::elf::{ElfArchitecture, ElfProgramType, ElfUsage};
 use crate::{
     fs::fs_manager::FileSystemID,
-    mem::vma::{VMA, VMAList, VMAInfo},
+    mem::vma::{VMAInfo, VMAList, VMA},
     paging::{PageManager, PageManagerDefault},
     user_program::elf::Elf,
     vfs::{INodeNum, OwnedPath},
@@ -64,9 +64,12 @@ impl ProcessControlBlock {
         drop(root);
         let mut vmas = VMAList::new();
         // set up stack
-        let stack_avail = vmas.add_vma(VMA::new(VMAInfo::Stack, USER_THREAD_STACK_SIZE, true), USER_STACK_BOTTOM_VIRT);
+        let stack_avail = vmas.add_vma(
+            VMA::new(VMAInfo::Stack, USER_THREAD_STACK_SIZE, true),
+            USER_STACK_BOTTOM_VIRT,
+        );
         assert!(stack_avail, "stack virtual address range not available");
-        
+
         let pcb = Self {
             pid,
             ppid: parent_pid,
@@ -297,7 +300,7 @@ impl ThreadControlBlock {
             kernel_stack_pointer_top = kernel_stack.add(KERNEL_THREAD_STACK_SIZE);
             write_bytes(kernel_stack.as_ptr(), 0, KERNEL_THREAD_STACK_SIZE);
         }
-/*
+        /*
         // TODO: We should only do this if there wasn't already a stack section
         // defined in the ELF file.
         let user_stack;

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -64,6 +64,7 @@ impl ProcessControlBlock {
         drop(root);
         let mut vmas = VMAList::new();
         // set up stack
+        // TODO: Handle stack section defined in the ELF file?
         let stack_avail = vmas.add_vma(
             VMA::new(VMAInfo::Stack, USER_THREAD_STACK_SIZE, true),
             USER_STACK_BOTTOM_VIRT,
@@ -300,27 +301,6 @@ impl ThreadControlBlock {
             kernel_stack_pointer_top = kernel_stack.add(KERNEL_THREAD_STACK_SIZE);
             write_bytes(kernel_stack.as_ptr(), 0, KERNEL_THREAD_STACK_SIZE);
         }
-        /*
-        // TODO: We should only do this if there wasn't already a stack section
-        // defined in the ELF file.
-        let user_stack;
-        unsafe {
-            user_stack = KERNEL_ALLOCATOR
-                .frame_alloc(USER_THREAD_STACK_FRAMES)
-                .expect("could not allocate user stack")
-                .cast::<u8>();
-            page_manager.map_range(
-                user_stack.as_ptr() as usize - OFFSET,
-                // TODO: This shouldn't be hardcoded, we need to ensure the ELF
-                // didn't already declare a stack section (we should be using
-                // that if it did), and that this doesn't overlap with any
-                // existing regions.
-                USER_STACK_BOTTOM_VIRT,
-                USER_THREAD_STACK_SIZE,
-                true,
-                true,
-            );
-        }*/
         (kernel_stack, kernel_stack_pointer_top)
     }
 

--- a/shared/src/paging.rs
+++ b/shared/src/paging.rs
@@ -236,10 +236,10 @@ impl<A: Allocator> PageManager<A> {
             let Ok(page_table_addr) = self.alloc.allocate(PAGE_TABLE_LAYOUT) else {
                 panic!("allocation failed");
             };
-
-            let page_table = page_table_addr.cast::<PageTable>().as_mut();
-            *page_table = PageTable::default();
-
+            let mut page_table_addr = page_table_addr.cast::<PageTable>();
+            // zero page table (uses less stack space than *page_table = PageTable::default() in debug build)
+            core::ptr::write_bytes(page_table_addr.as_ptr(), 0, 1);
+            let page_table = page_table_addr.as_mut();
             let page_table_phys_addr =
                 page_table_addr.cast::<u8>().as_ptr() as usize - self.phys_to_alloc_addr_offset;
             let page_table_frame = page_table_phys_addr / size_of::<PageTable>();


### PR DESCRIPTION
Currently the only VMA is the stack, which is now allocated on-demand rather than all at once when the process is created.

The stack physical memory isn't freed on process exit yet, but it looks like that wasn't happening before, so at least it's not a regression.
