### PR TITLE
Add nanosleep syscall

### DIFF
--- a/kernel/src/user_program/random.rs
+++ b/kernel/src/user_program/random.rs
@@ -22,7 +22,8 @@ fn generate_random_i32() -> Option<i32> {
 /// Returns the number of bytes written, or -1 if an error occurs.
 /// Currently no flags are implemented, if there is no random data available,
 /// the random data generated so far is returned.
-pub fn getrandom(buffer: &mut [u8], length: usize, _flags: usize) -> isize {
+pub fn getrandom(buffer: &mut [u8], _flags: usize) -> isize {
+    let length = buffer.len();
     let mut bytes_written: usize = 0;
     let chunks = length / 4;
     let remainder = length % 4;

--- a/kernel/src/user_program/syscall.rs
+++ b/kernel/src/user_program/syscall.rs
@@ -16,7 +16,6 @@ use crate::user_program::elf::Elf;
 use crate::user_program::random::getrandom;
 use crate::user_program::time::{get_rtc, get_tsc, Timespec, CLOCK_MONOTONIC, CLOCK_REALTIME};
 use alloc::boxed::Box;
-use core::slice::from_raw_parts_mut;
 use kidneyos_shared::println;
 pub use kidneyos_syscalls::defs::*;
 

--- a/syscalls/include/kidneyos.h
+++ b/syscalls/include/kidneyos.h
@@ -213,6 +213,6 @@ int32_t scheduler_yield(void);
 
 int32_t clock_gettime(int32_t clock_id, struct Timespec *timespec);
 
-int32_t getrandom(int8_t *buf, uintptr_t size, uintptr_t flags);
+int32_t getrandom(void *buf, uintptr_t size, uintptr_t flags);
 
 #endif  /* KIDNEYOS_SYSCALLS_H */

--- a/syscalls/src/defs.rs
+++ b/syscalls/src/defs.rs
@@ -1,5 +1,6 @@
 // syscall constants and types
 // These are in a separate file so that both the kernel code and userspace libc can include/use them.
+pub type Pid = u16;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -21,6 +22,12 @@ pub struct Dirent {
     pub r#type: u8,
     /// Null-terminated file name
     pub name: [u8; 0],
+}
+
+#[repr(C)]
+pub struct Timespec {
+    pub tv_sec: i64,
+    pub tv_nsec: i64,
 }
 
 pub const O_CREATE: usize = 0x40;

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,14 +1,6 @@
 #![no_std]
 
-use core::arch::asm;
-
-pub type Pid = u16;
-
-#[repr(C)]
-pub struct Timespec {
-    pub tv_sec: i64,
-    pub tv_nsec: i64,
-}
+use core::{arch::asm, ffi::c_void};
 
 pub mod defs;
 pub use defs::*;
@@ -395,7 +387,7 @@ pub extern "C" fn clock_gettime(clock_id: i32, timespec: *mut Timespec) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn getrandom(buf: *mut i8, size: usize, flags: usize) -> i32 {
+pub extern "C" fn getrandom(buf: *mut c_void, size: usize, flags: usize) -> i32 {
     let result: i32;
     unsafe {
         asm!(


### PR DESCRIPTION
Sleeps for the duration provided by timespec.

The amout of time waited seems to bit off, possibly because of an incorrect tick rate for QEMU.