### PR TITLE
Fix link formatting in doc comments

### DIFF
--- a/kernel/src/block/partitions/partition_core.rs
+++ b/kernel/src/block/partitions/partition_core.rs
@@ -11,7 +11,7 @@ use kidneyos_shared::{eprintln, println};
 
 /// A partition table entry in the MBR.
 ///
-/// Reference: https://wiki.osdev.org/MBR_(x86)#Partition_table_entry_format
+/// Reference: <https://wiki.osdev.org/MBR_(x86)#Partition_table_entry_format>
 pub(crate) struct PartitionTableEntry {
     /// 0x00    1   Drive attributes (bit 7 set = active or bootable)
     bootable: u8,
@@ -304,7 +304,7 @@ impl PartitionTableEntry {
 
 /// An MBR partition table.
 ///
-/// Reference: https://wiki.osdev.org/MBR_(x86)#MBR_format
+/// Reference: <https://wiki.osdev.org/MBR_(x86)#MBR_format>
 pub(crate) struct PartitionTable {
     /// 0x000   440     MBR Bootstrap (flat binary executable code)
     ///
@@ -319,7 +319,7 @@ pub(crate) struct PartitionTable {
     /// 0x1BC   2       Optional, reserved 0x0000
     ///
     /// The 2 byte reserved is usually 0x0000. 0x5A5A means read-only according to
-    /// https://neosmart.net/wiki/mbr-boot-process/
+    /// <https://neosmart.net/wiki/mbr-boot-process/>
     pub reserved: u16,
 
     /// 0x1BE   16      First partition table entry

--- a/kernel/src/drivers/ata/ata_channel.rs
+++ b/kernel/src/drivers/ata/ata_channel.rs
@@ -114,7 +114,8 @@ const CTL_HOB: u8 = 0x80;
 // Offsets -----------------------------------------------------------------------------------------
 
 /// Control Base offset
-/// Reference: https://lateblt.tripod.com/atapi.htm
+///
+/// Reference: <https://lateblt.tripod.com/atapi.htm>
 /// 0x3F6 - 0x1F0 = 0x206
 const CTL_OFFSET: u16 = 0x206;
 


### PR DESCRIPTION
cargo doc was giving a warning about this

```
warning: this URL is not a hyperlink
  --> kernel/src/block/partitions/partition_core.rs:14:16
   |
14 | /// Reference: https://wiki.osdev.org/MBR_(x86)#Partition_table_entry_format
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://wiki.osdev.org
etc.
```