### PR TITLE
Add handling of orphaned processes

### DIFF
--- a/kernel/src/rush/rush_core.rs
+++ b/kernel/src/rush/rush_core.rs
@@ -2,6 +2,7 @@ use crate::rush::env::{CURR_DIR, HOST_NAME};
 use crate::rush::parser::parse_input;
 use crate::sync::mutex::Mutex;
 use crate::system::unwrap_system;
+use crate::threading::idle_cleanup;
 use crate::threading::scheduling::scheduler_yield_and_continue;
 use alloc::string::String;
 use core::sync::atomic::AtomicBool;
@@ -58,6 +59,7 @@ pub extern "C" fn rush_loop() -> ! {
             print_prompt(false);
         }
 
+        idle_cleanup();
         scheduler_yield_and_continue(); // Until we can read input
     }
 }

--- a/kernel/src/threading/process.rs
+++ b/kernel/src/threading/process.rs
@@ -2,6 +2,8 @@ use super::thread_control_block::ProcessControlBlock;
 use crate::sync::{mutex::Mutex, rwlock::sleep::RwLock};
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU16, Ordering};
 
 pub type Pid = u16;
@@ -16,6 +18,7 @@ pub struct ProcessTable {
 
 pub struct ProcessState {
     pub table: ProcessTable,
+    pub orhpans: RwLock<Vec<Pid>>,
     next_tid: AtomicTid,
     next_pid: AtomicPid,
 }
@@ -23,6 +26,7 @@ pub struct ProcessState {
 pub fn create_process_state() -> ProcessState {
     ProcessState {
         table: Default::default(),
+        orhpans: RwLock::new(vec![]),
         next_tid: AtomicTid::new(1),
         next_pid: AtomicPid::new(1),
     }

--- a/kernel/src/threading/process_functions.rs
+++ b/kernel/src/threading/process_functions.rs
@@ -1,4 +1,4 @@
-use crate::system::{running_process, running_thread_tid};
+use crate::system::{running_process, running_thread_tid, unwrap_system};
 
 use super::{
     thread_functions::{self, stop_thread},
@@ -15,6 +15,17 @@ pub fn exit_process(exit_code: i32) -> ! {
     }
 
     let running_tid = running_thread_tid();
+
+    let system = unwrap_system();
+    let mut orphaned_pids = system.process.orhpans.write();
+
+    pcb.child_pids.iter().for_each(|child_pid| {
+        if let Some(child_pcb_ref) = system.process.table.get(*child_pid) {
+            let mut child_pcb = child_pcb_ref.lock();
+            child_pcb.ppid = 0;
+            orphaned_pids.push(*child_pid);
+        }
+    });
 
     // Kill all threads which are part of this process
     pcb.child_tids.iter().for_each(|tid| {

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -42,6 +42,8 @@ pub struct ProcessControlBlock {
     pub ppid: Pid,
     // The TIDs of this process' children threads
     pub child_tids: Vec<Tid>,
+    // The TIDs of processes spawned by this process
+    pub child_pids: Vec<Pid>,
     // The TIDs of the threads waiting on this process to end
     pub waiting_thread: Option<Tid>,
 
@@ -75,6 +77,7 @@ impl ProcessControlBlock {
             pid,
             ppid: parent_pid,
             child_tids: Vec::new(),
+            child_pids: Vec::new(),
             waiting_thread: None,
             exit_code: None,
             vmas,


### PR DESCRIPTION
Since there's no kernel PCB, PIDs of orphaned processes are added to a vector in the system state, and are removed by the idle thread.

This still needs teasting hence why it's marked as draft.