### PR TITLE
Documentation for execve/pipe/dup/dup2/brk/clone and other thread details

### DIFF
--- a/docs/syscalls/process/brk.md
+++ b/docs/syscalls/process/brk.md
@@ -1,0 +1,33 @@
+# Brk
+
+Increases/decreases the size of the heap
+
+### Synopsis
+
+```rs
+kidneyos_syscalls::brk;
+
+brk(ptr: *const u8) -> isize
+```
+
+```c
+#include "kidneyos.h"
+
+intptr_t brk(const uint8_t *ptr);
+```
+
+### Description
+
+Brk resizes the heap so that the **end** of the heap is `ptr` (not-exclusive, meaning dereferencing ptr would result in a fault, but ptr - 1 would be okay).
+
+Sbrk for linux is usually implemented as a C stdlib convenience, so we only expose brk here.
+
+### Return value
+
+On success, this function returns 0. On failure this function will return -1.
+
+This function can fail for a few reasons:
+
+ - The heap_end argument is in kernel space.
+ - The heap_end argument is before the mounted heap VMA (e.g. we would have a negative sized heap).
+ - The heap_end argument would extend the heap into another VMA (e.g. something mounted with mmap, or the stack).

--- a/docs/syscalls/process/clone.md
+++ b/docs/syscalls/process/clone.md
@@ -1,0 +1,38 @@
+# Clone
+
+Spawns another thread
+
+### Synopsis
+
+```rs
+kidneyos_syscalls::clone;
+
+clone(
+    flags: u32,
+    stack: *mut u8,
+    parent_tid: *mut Tid,
+    tls: u32,
+    child_tid: *mut Tid,
+) -> i32
+```
+
+```c
+#include "kidneyos.h"
+
+int32_t clone(uint32_t flags, uint8_t *stack, Tid *parent_tid, uint32_t tls, Tid *child_tid);
+```
+
+### Description
+
+Clone spawns another thead (new TCB with the same page manager) in the current process.
+
+Most parameters are ignored and reserved for future use. These are flags, parent_tid, tls, and child_tid.
+
+The `stack` argument is the value for the new threads `esp`. Threads cannot share a stack, so it is the responsibility of the callee to allocate new space for the thread (using brk).
+This argument cannot be passed as NULL (although this is supported in Linux). This still needs to be done.
+
+### Return value
+
+On success, this function returns 0. On failure this function will return -1 (for various reasons, see source code).
+
+The stack parameter is not checked for faults, only when the thread starts executing will this error be detected via interrupt.

--- a/docs/syscalls/process/dup.md
+++ b/docs/syscalls/process/dup.md
@@ -1,0 +1,30 @@
+# Dup
+
+Duplicates a file handle
+
+### Synopsis
+
+```rs
+kidneyos_syscalls::dup;
+
+dup(fd: i32) -> i32
+```
+
+```c
+#include "kidneyos.h"
+
+int32_t dup(int32_t fd);
+```
+
+### Description
+
+Returns another file handle that acts the same as the handle argument `fd`.
+
+This increments/clones any references to the original `fd`, so you are free to close the original fd knowing that a reference is maintained in the returned fd.
+
+### Return value
+
+On success, this function returns a valid FD. On error, one of the following values are returned:
+
+ - `-EBADF`: The `fd` argument did not refer to a valid file descriptor for this process.
+ - `-EMFILE`: Too many fds were established for this process (> 2^16).

--- a/docs/syscalls/process/dup2.md
+++ b/docs/syscalls/process/dup2.md
@@ -1,0 +1,30 @@
+# Dup2
+
+Changes the file descriptor table to "reconfigure" the value of an fd. "Clones" an fd into another fd value.
+
+### Synopsis
+
+```rs
+kidneyos_syscalls::dup2;
+
+fn dup2(old_fd: i32, new_fd: i32) -> i32
+```
+
+```c
+#include "kidneyos.h"
+
+int32_t dup2(int32_t old_fd, int32_t new_fd);
+```
+
+### Description
+
+Reconfigures `old_fd` to refer to `new_fd` in the file descriptor table.
+You can think of this as "redirecting" writes and read syscalls from `old_fd` to `new_fd`.
+
+This increments/clones any references to `new_fd`, so you are free to close the original fd knowing that a reference is maintained.
+
+### Return value
+
+On success, this function returns a valid FD. On error, one of the following values are returned:
+
+- `-EBADF`: The `old_fd` or `new_fd` arguments did not refer to a valid file descriptor for this process.

--- a/docs/syscalls/process/execve.md
+++ b/docs/syscalls/process/execve.md
@@ -24,6 +24,10 @@ The filename argument refers to an ELF-encoded x86 executable that will be parse
 This is accomplished by dropping the old TCB and creating a new one with the same PID (process parent).
 Multiple threads per processes is not extensively supported here, so extra handling needs to be done to properly handle this in a process with many threads.
 
+Both argv and envp **MUST** be NULL terminated. This means they contain null-terminated strings but their last element is also a NULL pointer.
+
+argv is passed to the thread using **Thread Arguments**. This value needs to be parsed into a slice for rust guest applications, or the size can be inferred by the guest process by iterating until NULL is found (the thread argument is also NULL terminated).
+
 envp is currently ignored, as there is no way for the guest executable to access arguments.
 
 ### Return value

--- a/docs/syscalls/process/execve.md
+++ b/docs/syscalls/process/execve.md
@@ -18,8 +18,19 @@ int32_t execve(const char *filename, const char *const *argv, const char *const 
 
 ### Description
 
-TODO
+Replaces the current process with another executable, specified by the filename argument.
+The filename argument refers to an ELF-encoded x86 executable that will be parsed and decoded.
+
+This is accomplished by dropping the old TCB and creating a new one with the same PID (process parent).
+Multiple threads per processes is not extensively supported here, so extra handling needs to be done to properly handle this in a process with many threads.
+
+envp is currently ignored, as there is no way for the guest executable to access arguments.
 
 ### Return value
 
-On sucess, this function does not return, on error, -1 is returned.
+On success, this function does not return. On error, one of the following values are returned:
+
+ - `-EFAULT`: The filename, argv, or envp arguments were invalid (do not point to a valid page, or point to NULL).
+ - `-ENOENT`: The filename argument was not a valid UTF-8 encoded string.
+ - `-EIO`: Filename did not refer to a valid file, or there was a problem reading the file at this path.
+ - `-ENOEXEC`: The file specified by filename was not an ELF file, or not an executable ELF, or the ELF architecture is not set to x86.

--- a/docs/syscalls/process/nanosleep.md
+++ b/docs/syscalls/process/nanosleep.md
@@ -22,4 +22,4 @@ Currently there is no way to interrupt a nanosleep call except for exiting the p
 
 ### Return value
 
-After sucessfully sleeping for `duration` 0 is returned. -1 is returned on error.
+After successfully sleeping for `duration` 0 is returned. -1 is returned on error.

--- a/docs/syscalls/process/pipe.md
+++ b/docs/syscalls/process/pipe.md
@@ -1,0 +1,34 @@
+# Pipe
+
+Create a cross-process "pipe" FD
+
+### Synopsis
+
+```rs
+kidneyos_syscalls::pipe;
+
+pipe(fds: *mut i32) -> i32
+```
+
+```c
+#include "kidneyos.h"
+
+int32_t pipe(int32_t *fds);
+```
+
+### Description
+
+Creates two fds that make up a directional pipe that can communicate across processes.
+Pipe must be called with a pointer to two consecutive fd handles. After a successful called to pipe, the fds array is initialized as such:
+
+ - `fds[0]` holds the read end of the pipe, and can be read from using the `read` syscall.
+ - `fds[1]` holds the write end of the pipe, and can be written to using the `write` syscall.
+
+Bytes written to `fds[1]` can be read from `fds[0]`. The pipes are reference counted, and when all read ends are closed, you may receive `-EPIPE` on proceeding writes.
+
+### Return value
+
+On success, this function will return 0. On error, one of the following values are returned:
+
+ - `-EFAULT`: The fds argument was invalid or NULL.
+ - `-EMFILE`: Too many fds were established for this process (> 2^16).


### PR DESCRIPTION
This PR documents some process related syscalls (**execve**, **pipe**, **dup**, **dup2**, **brk** and **clone**) and also sprinkles some details about threads and thread functionality.